### PR TITLE
NIFIREG-6 Adding nifi-registry-bootstrap module

### DIFF
--- a/nifi-registry-assembly/LICENSE
+++ b/nifi-registry-assembly/LICENSE
@@ -1,0 +1,210 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+APACHE NIFI SUBCOMPONENTS:
+
+The Apache NiFi project contains subcomponents with separate copyright
+notices and license terms. Your use of the source code for the these
+subcomponents is subject to the terms and conditions of the following
+licenses.
+

--- a/nifi-registry-assembly/NOTICE
+++ b/nifi-registry-assembly/NOTICE
@@ -1,0 +1,5 @@
+Apache NiFi Registry
+Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/nifi-registry-assembly/README.md
+++ b/nifi-registry-assembly/README.md
@@ -1,0 +1,44 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+# Apache NiFi Registry
+
+Registry—a subproject of Apache NiFi—is a complementary application that provides a central location for storage and management of shared resources across one or more instances of NiFi and/or MiNiFi.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [License](#license)
+
+## Getting Started
+
+TBD
+
+## License
+
+Except as otherwise noted this software is licensed under the
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/nifi-registry-assembly/pom.xml
+++ b/nifi-registry-assembly/pom.xml
@@ -77,6 +77,20 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi.registry</groupId>
+            <artifactId>nifi-registry-utils</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi.registry</groupId>
+            <artifactId>nifi-registry-bootstrap</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.nifi.registry</groupId>
             <artifactId>nifi-registry-runtime</artifactId>
             <version>0.0.1-SNAPSHOT</version>

--- a/nifi-registry-assembly/src/main/assembly/dependencies.xml
+++ b/nifi-registry-assembly/src/main/assembly/dependencies.xml
@@ -24,6 +24,35 @@
     <baseDirectory>nifi-registry-${project.version}</baseDirectory>
 
     <dependencySets>
+        <!-- Write out the dependencies shared between bootstrap and the main app to lib/shared -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib/shared</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0660</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>nifi-registry-utils</include>
+                <include>commons-lang3</include>
+            </includes>
+        </dependencySet>
+
+        <!-- Write out the bootstrap lib component to its own dir -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib/bootstrap</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0660</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>nifi-registry-bootstrap</include>
+                <include>slf4j-api</include>
+                <include>logback-classic</include>
+            </includes>
+        </dependencySet>
+
         <!-- Write out all dependency artifacts to lib directory -->
         <dependencySet>
             <scope>runtime</scope>
@@ -34,6 +63,8 @@
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
                 <exclude>nifi-registry-resources</exclude>
+                <exclude>nifi-registry-bootstrap</exclude>
+                <exclude>nifi-registry-utils</exclude>
             </excludes>
         </dependencySet>
         
@@ -77,4 +108,29 @@
             </unpackOptions>
         </dependencySet>
     </dependencySets>
+
+    <files>
+        <file>
+            <source>./README.md</source>
+            <outputDirectory>./</outputDirectory>
+            <destName>README</destName>
+            <fileMode>0644</fileMode>
+            <filtered>true</filtered>
+        </file>
+        <file>
+            <source>./LICENSE</source>
+            <outputDirectory>./</outputDirectory>
+            <destName>LICENSE</destName>
+            <fileMode>0644</fileMode>
+            <filtered>true</filtered>
+        </file>
+        <file>
+            <source>./NOTICE</source>
+            <outputDirectory>./</outputDirectory>
+            <destName>NOTICE</destName>
+            <fileMode>0644</fileMode>
+            <filtered>true</filtered>
+        </file>
+    </files>
+
 </assembly>

--- a/nifi-registry-bootstrap/pom.xml
+++ b/nifi-registry-bootstrap/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+    license agreements. See the NOTICE file distributed with this work for additional 
+    information regarding copyright ownership. The ASF licenses this file to 
+    You under the Apache License, Version 2.0 (the "License"); you may not use 
+    this file except in compliance with the License. You may obtain a copy of 
+    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+    by applicable law or agreed to in writing, software distributed under the 
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    OF ANY KIND, either express or implied. See the License for the specific 
+    language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi.registry</groupId>
+        <artifactId>nifi-registry</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>nifi-registry-bootstrap</artifactId>
+    <packaging>jar</packaging>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.nifi.registry</groupId>
+            <artifactId>nifi-registry-utils</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>4.4.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/BootstrapCodec.java
+++ b/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/BootstrapCodec.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.bootstrap;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+
+import org.apache.nifi.registry.bootstrap.exception.InvalidCommandException;
+
+public class BootstrapCodec {
+
+    private final RunNiFiRegistry runner;
+    private final BufferedReader reader;
+    private final BufferedWriter writer;
+
+    public BootstrapCodec(final RunNiFiRegistry runner, final InputStream in, final OutputStream out) {
+        this.runner = runner;
+        this.reader = new BufferedReader(new InputStreamReader(in));
+        this.writer = new BufferedWriter(new OutputStreamWriter(out));
+    }
+
+    public void communicate() throws IOException {
+        final String line = reader.readLine();
+        final String[] splits = line.split(" ");
+        if (splits.length < 0) {
+            throw new IOException("Received invalid command from NiFi Registry: " + line);
+        }
+
+        final String cmd = splits[0];
+        final String[] args;
+        if (splits.length == 1) {
+            args = new String[0];
+        } else {
+            args = Arrays.copyOfRange(splits, 1, splits.length);
+        }
+
+        try {
+            processRequest(cmd, args);
+        } catch (final InvalidCommandException ice) {
+            throw new IOException("Received invalid command from NiFi Registry: " + line + (ice.getMessage() == null ? "" : " - Details: " + ice.toString()));
+        }
+    }
+
+    private void processRequest(final String cmd, final String[] args) throws InvalidCommandException, IOException {
+        switch (cmd) {
+            case "PORT": {
+                if (args.length != 2) {
+                    throw new InvalidCommandException();
+                }
+
+                final int port;
+                try {
+                    port = Integer.parseInt(args[0]);
+                } catch (final NumberFormatException nfe) {
+                    throw new InvalidCommandException("Invalid Port number; should be integer between 1 and 65535");
+                }
+
+                if (port < 1 || port > 65535) {
+                    throw new InvalidCommandException("Invalid Port number; should be integer between 1 and 65535");
+                }
+
+                final String secretKey = args[1];
+
+                runner.setNiFiRegistryCommandControlPort(port, secretKey);
+                writer.write("OK");
+                writer.newLine();
+                writer.flush();
+            }
+            break;
+            case "STARTED": {
+                if (args.length != 1) {
+                    throw new InvalidCommandException("STARTED command must contain a status argument");
+                }
+
+                if (!"true".equals(args[0]) && !"false".equals(args[0])) {
+                    throw new InvalidCommandException("Invalid status for STARTED command; should be true or false, but was '" + args[0] + "'");
+                }
+
+                final boolean started = Boolean.parseBoolean(args[0]);
+                runner.setNiFiRegistryStarted(started);
+                writer.write("OK");
+                writer.newLine();
+                writer.flush();
+            }
+            break;
+        }
+    }
+}

--- a/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/NiFiRegistryListener.java
+++ b/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/NiFiRegistryListener.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.bootstrap;
+
+import org.apache.nifi.registry.bootstrap.util.LimitingInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+public class NiFiRegistryListener {
+
+    private ServerSocket serverSocket;
+    private volatile Listener listener;
+
+    int start(final RunNiFiRegistry runner) throws IOException {
+        serverSocket = new ServerSocket();
+        serverSocket.bind(new InetSocketAddress("localhost", 0));
+
+        final int localPort = serverSocket.getLocalPort();
+        listener = new Listener(serverSocket, runner);
+        final Thread listenThread = new Thread(listener);
+        listenThread.setName("Listen to NiFi Registry");
+        listenThread.setDaemon(true);
+        listenThread.start();
+        return localPort;
+    }
+
+    public void stop() throws IOException {
+        final Listener listener = this.listener;
+        if (listener == null) {
+            return;
+        }
+
+        listener.stop();
+    }
+
+    private class Listener implements Runnable {
+
+        private final ServerSocket serverSocket;
+        private final ExecutorService executor;
+        private final RunNiFiRegistry runner;
+        private volatile boolean stopped = false;
+
+        public Listener(final ServerSocket serverSocket, final RunNiFiRegistry runner) {
+            this.serverSocket = serverSocket;
+            this.executor = Executors.newFixedThreadPool(2, new ThreadFactory() {
+                @Override
+                public Thread newThread(final Runnable runnable) {
+                    final Thread t = Executors.defaultThreadFactory().newThread(runnable);
+                    t.setDaemon(true);
+                    t.setName("NiFi Registry Bootstrap Command Listener");
+                    return t;
+                }
+            });
+
+            this.runner = runner;
+        }
+
+        public void stop() throws IOException {
+            stopped = true;
+
+            executor.shutdown();
+            try {
+                executor.awaitTermination(3, TimeUnit.SECONDS);
+            } catch (final InterruptedException ie) {
+            }
+
+            serverSocket.close();
+        }
+
+        @Override
+        public void run() {
+            while (!serverSocket.isClosed()) {
+                try {
+                    if (stopped) {
+                        return;
+                    }
+
+                    final Socket socket;
+                    try {
+                        socket = serverSocket.accept();
+                    } catch (final IOException ioe) {
+                        if (stopped) {
+                            return;
+                        }
+
+                        throw ioe;
+                    }
+
+                    executor.submit(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                // we want to ensure that we don't try to read data from an InputStream directly
+                                // by a BufferedReader because any user on the system could open a socket and send
+                                // a multi-gigabyte file without any new lines in order to crash the Bootstrap,
+                                // which in turn may cause the Shutdown Hook to shutdown NiFi.
+                                // So we will limit the amount of data to read to 4 KB
+                                final InputStream limitingIn = new LimitingInputStream(socket.getInputStream(), 4096);
+                                final BootstrapCodec codec = new BootstrapCodec(runner, limitingIn, socket.getOutputStream());
+                                codec.communicate();
+                            } catch (final Throwable t) {
+                                System.out.println("Failed to communicate with NiFi Registry due to " + t);
+                                t.printStackTrace();
+                            } finally {
+                                try {
+                                    socket.close();
+                                } catch (final IOException ioe) {
+                                }
+                            }
+                        }
+                    });
+                } catch (final Throwable t) {
+                    System.err.println("Failed to receive information from NiFi Registry due to " + t);
+                    t.printStackTrace();
+                }
+            }
+        }
+    }
+}

--- a/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/RunNiFiRegistry.java
+++ b/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/RunNiFiRegistry.java
@@ -1,0 +1,1280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.bootstrap;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.FileAlreadyExistsException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.registry.bootstrap.util.OSUtils;
+import org.apache.nifi.registry.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>
+ * The class which bootstraps Apache NiFi Registry. This class looks for the
+ * bootstrap.conf file by looking in the following places (in order):</p>
+ * <ol>
+ * <li>Java System Property named
+ * {@code org.apache.nifi.registry.bootstrap.config.file}</li>
+ * <li>${NIFI_HOME}/./conf/bootstrap.conf, where ${NIFI_REGISTRY_HOME} references an
+ * environment variable {@code NIFI_REGISTRY_HOME}</li>
+ * <li>./conf/bootstrap.conf, where {@code ./} represents the working
+ * directory.</li>
+ * </ol>
+ * <p>
+ * If the {@code bootstrap.conf} file cannot be found, throws a {@code FileNotFoundException}.
+ */
+public class RunNiFiRegistry {
+
+    public static final String DEFAULT_CONFIG_FILE = "./conf/bootstrap.conf";
+    public static final String DEFAULT_JAVA_CMD = "java";
+    public static final String DEFAULT_PID_DIR = "bin";
+    public static final String DEFAULT_LOG_DIR = "./logs";
+
+    public static final String GRACEFUL_SHUTDOWN_PROP = "graceful.shutdown.seconds";
+    public static final String DEFAULT_GRACEFUL_SHUTDOWN_VALUE = "20";
+
+    public static final String NIFI_REGISTRY_PID_DIR_PROP = "org.apache.nifi.registry.bootstrap.config.pid.dir";
+    public static final String NIFI_REGISTRY_PID_FILE_NAME = "nifi-registry.pid";
+    public static final String NIFI_REGISTRY_STATUS_FILE_NAME = "nifi-registry.status";
+    public static final String NIFI_REGISTRY_LOCK_FILE_NAME = "nifi-registry.lock";
+    public static final String NIFI_REGISTRY_BOOTSTRAP_SENSITIVE_KEY = "nifi.registry.bootstrap.sensitive.key";
+
+    public static final String PID_KEY = "pid";
+
+    public static final int STARTUP_WAIT_SECONDS = 60;
+
+    public static final String SHUTDOWN_CMD = "SHUTDOWN";
+    public static final String PING_CMD = "PING";
+    public static final String DUMP_CMD = "DUMP";
+
+    private volatile boolean autoRestartNiFiRegistry = true;
+    private volatile int ccPort = -1;
+    private volatile long nifiRegistryPid = -1L;
+    private volatile String secretKey;
+    private volatile ShutdownHook shutdownHook;
+    private volatile boolean nifiRegistryStarted;
+
+    private final Lock startedLock = new ReentrantLock();
+    private final Lock lock = new ReentrantLock();
+    private final Condition startupCondition = lock.newCondition();
+
+    private final File bootstrapConfigFile;
+
+    // used for logging initial info; these will be logged to console by default when the app is started
+    private final Logger cmdLogger = LoggerFactory.getLogger("org.apache.nifi.registry.bootstrap.Command");
+    // used for logging all info. These by default will be written to the log file
+    private final Logger defaultLogger = LoggerFactory.getLogger(RunNiFiRegistry.class);
+
+
+    private final ExecutorService loggingExecutor;
+    private volatile Set<Future<?>> loggingFutures = new HashSet<>(2);
+
+    public RunNiFiRegistry(final File bootstrapConfigFile, final boolean verbose) throws IOException {
+        this.bootstrapConfigFile = bootstrapConfigFile;
+
+        loggingExecutor = Executors.newFixedThreadPool(2, new ThreadFactory() {
+            @Override
+            public Thread newThread(final Runnable runnable) {
+                final Thread t = Executors.defaultThreadFactory().newThread(runnable);
+                t.setDaemon(true);
+                t.setName("NiFi logging handler");
+                return t;
+            }
+        });
+    }
+
+    private static void printUsage() {
+        System.out.println("Usage:");
+        System.out.println();
+        System.out.println("java org.apache.nifi.bootstrap.RunNiFiRegistry [<-verbose>] <command> [options]");
+        System.out.println();
+        System.out.println("Valid commands include:");
+        System.out.println("");
+        System.out.println("Start : Start a new instance of Apache NiFi Registry");
+        System.out.println("Stop : Stop a running instance of Apache NiFi Registry");
+        System.out.println("Restart : Stop Apache NiFi Registry, if it is running, and then start a new instance");
+        System.out.println("Status : Determine if there is a running instance of Apache NiFi Registry");
+        System.out.println("Dump : Write a Thread Dump to the file specified by [options], or to the log if no file is given");
+        System.out.println("Run : Start a new instance of Apache NiFi Registry and monitor the Process, restarting if the instance dies");
+        System.out.println();
+    }
+
+    private static String[] shift(final String[] orig) {
+        return Arrays.copyOfRange(orig, 1, orig.length);
+    }
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        if (args.length < 1 || args.length > 3) {
+            printUsage();
+            return;
+        }
+
+        File dumpFile = null;
+        boolean verbose = false;
+        if (args[0].equals("-verbose")) {
+            verbose = true;
+            args = shift(args);
+        }
+
+        final String cmd = args[0];
+        if (cmd.equals("dump")) {
+            if (args.length > 1) {
+                dumpFile = new File(args[1]);
+            } else {
+                dumpFile = null;
+            }
+        }
+
+        switch (cmd.toLowerCase()) {
+            case "start":
+            case "run":
+            case "stop":
+            case "status":
+            case "dump":
+            case "restart":
+            case "env":
+                break;
+            default:
+                printUsage();
+                return;
+        }
+
+        final File configFile = getDefaultBootstrapConfFile();
+        final RunNiFiRegistry runNiFiRegistry = new RunNiFiRegistry(configFile, verbose);
+
+        Integer exitStatus = null;
+        switch (cmd.toLowerCase()) {
+            case "start":
+                runNiFiRegistry.start();
+                break;
+            case "run":
+                runNiFiRegistry.start();
+                break;
+            case "stop":
+                runNiFiRegistry.stop();
+                break;
+            case "status":
+                exitStatus = runNiFiRegistry.status();
+                break;
+            case "restart":
+                runNiFiRegistry.stop();
+                runNiFiRegistry.start();
+                break;
+            case "dump":
+                runNiFiRegistry.dump(dumpFile);
+                break;
+            case "env":
+                runNiFiRegistry.env();
+                break;
+        }
+        if (exitStatus != null) {
+            System.exit(exitStatus);
+        }
+    }
+
+    private static File getDefaultBootstrapConfFile() {
+        String configFilename = System.getProperty("org.apache.nifi.registry.bootstrap.config.file");
+
+        if (configFilename == null) {
+            final String nifiRegistryHome = System.getenv("NIFI_REGISTRY_HOME");
+            if (nifiRegistryHome != null) {
+                final File nifiRegistryHomeFile = new File(nifiRegistryHome.trim());
+                final File configFile = new File(nifiRegistryHomeFile, DEFAULT_CONFIG_FILE);
+                configFilename = configFile.getAbsolutePath();
+            }
+        }
+
+        if (configFilename == null) {
+            configFilename = DEFAULT_CONFIG_FILE;
+        }
+
+        final File configFile = new File(configFilename);
+        return configFile;
+    }
+
+    protected File getBootstrapFile(final Logger logger, String directory, String defaultDirectory, String fileName) throws IOException {
+
+        final File confDir = bootstrapConfigFile.getParentFile();
+        final File nifiHome = confDir.getParentFile();
+
+        String confFileDir = System.getProperty(directory);
+
+        final File fileDir;
+
+        if (confFileDir != null) {
+            fileDir = new File(confFileDir.trim());
+        } else {
+            fileDir = new File(nifiHome, defaultDirectory);
+        }
+
+        FileUtils.ensureDirectoryExistAndCanAccess(fileDir);
+        final File statusFile = new File(fileDir, fileName);
+        logger.debug("Status File: {}", statusFile);
+        return statusFile;
+    }
+
+    protected File getPidFile(final Logger logger) throws IOException {
+        return getBootstrapFile(logger, NIFI_REGISTRY_PID_DIR_PROP, DEFAULT_PID_DIR, NIFI_REGISTRY_PID_FILE_NAME);
+    }
+
+    protected File getStatusFile(final Logger logger) throws IOException {
+        return getBootstrapFile(logger, NIFI_REGISTRY_PID_DIR_PROP, DEFAULT_PID_DIR, NIFI_REGISTRY_STATUS_FILE_NAME);
+    }
+
+    protected File getLockFile(final Logger logger) throws IOException {
+        return getBootstrapFile(logger, NIFI_REGISTRY_PID_DIR_PROP, DEFAULT_PID_DIR, NIFI_REGISTRY_LOCK_FILE_NAME);
+    }
+
+    protected File getStatusFile() throws IOException {
+        return getStatusFile(defaultLogger);
+    }
+
+    private Properties loadProperties(final Logger logger) throws IOException {
+        final Properties props = new Properties();
+        final File statusFile = getStatusFile(logger);
+        if (statusFile == null || !statusFile.exists()) {
+            logger.debug("No status file to load properties from");
+            return props;
+        }
+
+        try (final FileInputStream fis = new FileInputStream(getStatusFile(logger))) {
+            props.load(fis);
+        }
+
+        final Map<Object, Object> modified = new HashMap<>(props);
+        modified.remove("secret.key");
+        logger.debug("Properties: {}", modified);
+
+        return props;
+    }
+
+    private synchronized void savePidProperties(final Properties pidProperties, final Logger logger) throws IOException {
+        final String pid = pidProperties.getProperty(PID_KEY);
+        if (!StringUtils.isBlank(pid)) {
+            writePidFile(pid, logger);
+        }
+
+        final File statusFile = getStatusFile(logger);
+        if (statusFile.exists() && !statusFile.delete()) {
+            logger.warn("Failed to delete {}", statusFile);
+        }
+
+        if (!statusFile.createNewFile()) {
+            throw new IOException("Failed to create file " + statusFile);
+        }
+
+        try {
+            final Set<PosixFilePermission> perms = new HashSet<>();
+            perms.add(PosixFilePermission.OWNER_READ);
+            perms.add(PosixFilePermission.OWNER_WRITE);
+            Files.setPosixFilePermissions(statusFile.toPath(), perms);
+        } catch (final Exception e) {
+            logger.warn("Failed to set permissions so that only the owner can read status file {}; "
+                    + "this may allows others to have access to the key needed to communicate with NiFi Registry. "
+                    + "Permissions should be changed so that only the owner can read this file", statusFile);
+        }
+
+        try (final FileOutputStream fos = new FileOutputStream(statusFile)) {
+            pidProperties.store(fos, null);
+            fos.getFD().sync();
+        }
+
+        logger.debug("Saved Properties {} to {}", new Object[]{pidProperties, statusFile});
+    }
+
+    private synchronized void writePidFile(final String pid, final Logger logger) throws IOException {
+        final File pidFile = getPidFile(logger);
+        if (pidFile.exists() && !pidFile.delete()) {
+            logger.warn("Failed to delete {}", pidFile);
+        }
+
+        if (!pidFile.createNewFile()) {
+            throw new IOException("Failed to create file " + pidFile);
+        }
+
+        try {
+            final Set<PosixFilePermission> perms = new HashSet<>();
+            perms.add(PosixFilePermission.OWNER_WRITE);
+            perms.add(PosixFilePermission.OWNER_READ);
+            perms.add(PosixFilePermission.GROUP_READ);
+            perms.add(PosixFilePermission.OTHERS_READ);
+            Files.setPosixFilePermissions(pidFile.toPath(), perms);
+        } catch (final Exception e) {
+            logger.warn("Failed to set permissions so that only the owner can read pid file {}; "
+                    + "this may allows others to have access to the key needed to communicate with NiFi Registry. "
+                    + "Permissions should be changed so that only the owner can read this file", pidFile);
+        }
+
+        try (final FileOutputStream fos = new FileOutputStream(pidFile)) {
+            fos.write(pid.getBytes(StandardCharsets.UTF_8));
+            fos.getFD().sync();
+        }
+
+        logger.debug("Saved Pid {} to {}", new Object[]{pid, pidFile});
+    }
+
+    private boolean isPingSuccessful(final int port, final String secretKey, final Logger logger) {
+        logger.debug("Pinging {}", port);
+
+        try (final Socket socket = new Socket("localhost", port)) {
+            final OutputStream out = socket.getOutputStream();
+            out.write((PING_CMD + " " + secretKey + "\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+
+            logger.debug("Sent PING command");
+            socket.setSoTimeout(5000);
+            final InputStream in = socket.getInputStream();
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+            final String response = reader.readLine();
+            logger.debug("PING response: {}", response);
+            out.close();
+            reader.close();
+
+            return PING_CMD.equals(response);
+        } catch (final IOException ioe) {
+            return false;
+        }
+    }
+
+    private Integer getCurrentPort(final Logger logger) throws IOException {
+        final Properties props = loadProperties(logger);
+        final String portVal = props.getProperty("port");
+        if (portVal == null) {
+            logger.debug("No Port found in status file");
+            return null;
+        } else {
+            logger.debug("Port defined in status file: {}", portVal);
+        }
+
+        final int port = Integer.parseInt(portVal);
+        final boolean success = isPingSuccessful(port, props.getProperty("secret.key"), logger);
+        if (success) {
+            logger.debug("Successful PING on port {}", port);
+            return port;
+        }
+
+        final String pid = props.getProperty(PID_KEY);
+        logger.debug("PID in status file is {}", pid);
+        if (pid != null) {
+            final boolean procRunning = isProcessRunning(pid, logger);
+            if (procRunning) {
+                return port;
+            } else {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private boolean isProcessRunning(final String pid, final Logger logger) {
+        try {
+            // We use the "ps" command to check if the process is still running.
+            final ProcessBuilder builder = new ProcessBuilder();
+
+            builder.command("ps", "-p", pid);
+            final Process proc = builder.start();
+
+            // Look for the pid in the output of the 'ps' command.
+            boolean running = false;
+            String line;
+            try (final InputStream in = proc.getInputStream();
+                 final Reader streamReader = new InputStreamReader(in);
+                 final BufferedReader reader = new BufferedReader(streamReader)) {
+
+                while ((line = reader.readLine()) != null) {
+                    if (line.trim().startsWith(pid)) {
+                        running = true;
+                    }
+                }
+            }
+
+            // If output of the ps command had our PID, the process is running.
+            if (running) {
+                logger.debug("Process with PID {} is running", pid);
+            } else {
+                logger.debug("Process with PID {} is not running", pid);
+            }
+
+            return running;
+        } catch (final IOException ioe) {
+            System.err.println("Failed to determine if Process " + pid + " is running; assuming that it is not");
+            return false;
+        }
+    }
+
+    private Status getStatus(final Logger logger) {
+        final Properties props;
+        try {
+            props = loadProperties(logger);
+        } catch (final IOException ioe) {
+            return new Status(null, null, false, false);
+        }
+
+        if (props == null) {
+            return new Status(null, null, false, false);
+        }
+
+        final String portValue = props.getProperty("port");
+        final String pid = props.getProperty(PID_KEY);
+        final String secretKey = props.getProperty("secret.key");
+
+        if (portValue == null && pid == null) {
+            return new Status(null, null, false, false);
+        }
+
+        Integer port = null;
+        boolean pingSuccess = false;
+        if (portValue != null) {
+            try {
+                port = Integer.parseInt(portValue);
+                pingSuccess = isPingSuccessful(port, secretKey, logger);
+            } catch (final NumberFormatException nfe) {
+                return new Status(null, null, false, false);
+            }
+        }
+
+        if (pingSuccess) {
+            return new Status(port, pid, true, true);
+        }
+
+        final boolean alive = pid != null && isProcessRunning(pid, logger);
+        return new Status(port, pid, pingSuccess, alive);
+    }
+
+    public int status() throws IOException {
+        final Logger logger = cmdLogger;
+        final Status status = getStatus(logger);
+        if (status.isRespondingToPing()) {
+            logger.info("Apache NiFi Registry is currently running, listening to Bootstrap on port {}, PID={}",
+                    new Object[]{status.getPort(), status.getPid() == null ? "unknown" : status.getPid()});
+            return 0;
+        }
+
+        if (status.isProcessRunning()) {
+            logger.info("Apache NiFi Registry is running at PID {} but is not responding to ping requests", status.getPid());
+            return 4;
+        }
+
+        if (status.getPort() == null) {
+            logger.info("Apache NiFi Registry is not running");
+            return 3;
+        }
+
+        if (status.getPid() == null) {
+            logger.info("Apache NiFi Registry is not responding to Ping requests. The process may have died or may be hung");
+        } else {
+            logger.info("Apache NiFi Registry is not running");
+        }
+        return 3;
+    }
+
+    public void env() {
+        final Logger logger = cmdLogger;
+        final Status status = getStatus(logger);
+        if (status.getPid() == null) {
+            logger.info("Apache NiFi Registry is not running");
+            return;
+        }
+        final Class<?> virtualMachineClass;
+        try {
+            virtualMachineClass = Class.forName("com.sun.tools.attach.VirtualMachine");
+        } catch (final ClassNotFoundException cnfe) {
+            logger.error("Seems tools.jar (Linux / Windows JDK) or classes.jar (Mac OS) is not available in classpath");
+            return;
+        }
+        final Method attachMethod;
+        final Method detachMethod;
+
+        try {
+            attachMethod = virtualMachineClass.getMethod("attach", String.class);
+            detachMethod = virtualMachineClass.getDeclaredMethod("detach");
+        } catch (final Exception e) {
+            logger.error("Methods required for getting environment not available", e);
+            return;
+        }
+
+        final Object virtualMachine;
+        try {
+            virtualMachine = attachMethod.invoke(null, status.getPid());
+        } catch (final Throwable t) {
+            logger.error("Problem attaching to NiFi", t);
+            return;
+        }
+
+        try {
+            final Method getSystemPropertiesMethod = virtualMachine.getClass().getMethod("getSystemProperties");
+
+            final Properties sysProps = (Properties) getSystemPropertiesMethod.invoke(virtualMachine);
+            for (Entry<Object, Object> syspropEntry : sysProps.entrySet()) {
+                logger.info(syspropEntry.getKey().toString() + " = " + syspropEntry.getValue().toString());
+            }
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        } finally {
+            try {
+                detachMethod.invoke(virtualMachine);
+            } catch (final Exception e) {
+                logger.warn("Caught exception detaching from process", e);
+            }
+        }
+    }
+
+    /**
+     * Writes a NiFi thread dump to the given file; if file is null, logs at
+     * INFO level instead.
+     *
+     * @param dumpFile the file to write the dump content to
+     * @throws IOException if any issues occur while writing the dump file
+     */
+    public void dump(final File dumpFile) throws IOException {
+        final Logger logger = defaultLogger;    // dump to bootstrap log file by default
+        final Integer port = getCurrentPort(logger);
+        if (port == null) {
+            logger.info("Apache NiFi Registry is not currently running");
+            return;
+        }
+
+        final Properties nifiRegistryProps = loadProperties(logger);
+        final String secretKey = nifiRegistryProps.getProperty("secret.key");
+
+        final StringBuilder sb = new StringBuilder();
+        try (final Socket socket = new Socket()) {
+            logger.debug("Connecting to NiFi Registry instance");
+            socket.setSoTimeout(60000);
+            socket.connect(new InetSocketAddress("localhost", port));
+            logger.debug("Established connection to NiFi Registry instance.");
+            socket.setSoTimeout(60000);
+
+            logger.debug("Sending DUMP Command to port {}", port);
+            final OutputStream out = socket.getOutputStream();
+            out.write((DUMP_CMD + " " + secretKey + "\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+
+            final InputStream in = socket.getInputStream();
+            try (final BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    sb.append(line).append("\n");
+                }
+            }
+        }
+
+        final String dump = sb.toString();
+        if (dumpFile == null) {
+            logger.info(dump);
+        } else {
+            try (final FileOutputStream fos = new FileOutputStream(dumpFile)) {
+                fos.write(dump.getBytes(StandardCharsets.UTF_8));
+            }
+            // we want to log to the console (by default) that we wrote the thread dump to the specified file
+            cmdLogger.info("Successfully wrote thread dump to {}", dumpFile.getAbsolutePath());
+        }
+    }
+
+    public void notifyStop() {
+        final String hostname = getHostname();
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS");
+        final String now = sdf.format(System.currentTimeMillis());
+        String user = System.getProperty("user.name");
+        if (user == null || user.trim().isEmpty()) {
+            user = "Unknown User";
+        }
+    }
+
+    public void stop() throws IOException {
+        final Logger logger = cmdLogger;
+        final Integer port = getCurrentPort(logger);
+        if (port == null) {
+            logger.info("Apache NiFi Registry is not currently running");
+            return;
+        }
+
+        // indicate that a stop command is in progress
+        final File lockFile = getLockFile(logger);
+        if (!lockFile.exists()) {
+            lockFile.createNewFile();
+        }
+
+        final Properties nifiRegistryProps = loadProperties(logger);
+        final String secretKey = nifiRegistryProps.getProperty("secret.key");
+        final String pid = nifiRegistryProps.getProperty(PID_KEY);
+        final File statusFile = getStatusFile(logger);
+        final File pidFile = getPidFile(logger);
+
+        try (final Socket socket = new Socket()) {
+            logger.debug("Connecting to NiFi Registry instance");
+            socket.setSoTimeout(10000);
+            socket.connect(new InetSocketAddress("localhost", port));
+            logger.debug("Established connection to NiFi Registry instance.");
+            socket.setSoTimeout(10000);
+
+            logger.debug("Sending SHUTDOWN Command to port {}", port);
+            final OutputStream out = socket.getOutputStream();
+            out.write((SHUTDOWN_CMD + " " + secretKey + "\n").getBytes(StandardCharsets.UTF_8));
+            out.flush();
+            socket.shutdownOutput();
+
+            final InputStream in = socket.getInputStream();
+            int lastChar;
+            final StringBuilder sb = new StringBuilder();
+            while ((lastChar = in.read()) > -1) {
+                sb.append((char) lastChar);
+            }
+            final String response = sb.toString().trim();
+
+            logger.debug("Received response to SHUTDOWN command: {}", response);
+
+            if (SHUTDOWN_CMD.equals(response)) {
+                logger.info("Apache NiFi Registry has accepted the Shutdown Command and is shutting down now");
+
+                if (pid != null) {
+                    final Properties bootstrapProperties = new Properties();
+                    try (final FileInputStream fis = new FileInputStream(bootstrapConfigFile)) {
+                        bootstrapProperties.load(fis);
+                    }
+
+                    String gracefulShutdown = bootstrapProperties.getProperty(GRACEFUL_SHUTDOWN_PROP, DEFAULT_GRACEFUL_SHUTDOWN_VALUE);
+                    int gracefulShutdownSeconds;
+                    try {
+                        gracefulShutdownSeconds = Integer.parseInt(gracefulShutdown);
+                    } catch (final NumberFormatException nfe) {
+                        gracefulShutdownSeconds = Integer.parseInt(DEFAULT_GRACEFUL_SHUTDOWN_VALUE);
+                    }
+
+                    notifyStop();
+                    final long startWait = System.nanoTime();
+                    while (isProcessRunning(pid, logger)) {
+                        logger.info("Waiting for Apache NiFi Registry to finish shutting down...");
+                        final long waitNanos = System.nanoTime() - startWait;
+                        final long waitSeconds = TimeUnit.NANOSECONDS.toSeconds(waitNanos);
+                        if (waitSeconds >= gracefulShutdownSeconds && gracefulShutdownSeconds > 0) {
+                            if (isProcessRunning(pid, logger)) {
+                                logger.warn("NiFi Registry has not finished shutting down after {} seconds. Killing process.", gracefulShutdownSeconds);
+                                try {
+                                    killProcessTree(pid, logger);
+                                } catch (final IOException ioe) {
+                                    logger.error("Failed to kill Process with PID {}", pid);
+                                }
+                            }
+                            break;
+                        } else {
+                            try {
+                                Thread.sleep(2000L);
+                            } catch (final InterruptedException ie) {
+                            }
+                        }
+                    }
+
+                    if (statusFile.exists() && !statusFile.delete()) {
+                        logger.error("Failed to delete status file {}; this file should be cleaned up manually", statusFile);
+                    }
+
+                    if (pidFile.exists() && !pidFile.delete()) {
+                        logger.error("Failed to delete pid file {}; this file should be cleaned up manually", pidFile);
+                    }
+
+                    logger.info("NiFi Registry has finished shutting down.");
+                }
+            } else {
+                logger.error("When sending SHUTDOWN command to NiFi Registry , got unexpected response {}", response);
+            }
+        } catch (final IOException ioe) {
+            if (pid == null) {
+                logger.error("Failed to send shutdown command to port {} due to {}. No PID found for the NiFi Registry process, so unable to kill process; "
+                        + "the process should be killed manually.", new Object[]{port, ioe.toString()});
+            } else {
+                logger.error("Failed to send shutdown command to port {} due to {}. Will kill the NiFi Registry Process with PID {}.", port, ioe.toString(), pid);
+                notifyStop();
+                killProcessTree(pid, logger);
+                if (statusFile.exists() && !statusFile.delete()) {
+                    logger.error("Failed to delete status file {}; this file should be cleaned up manually", statusFile);
+                }
+            }
+        } finally {
+            if (lockFile.exists() && !lockFile.delete()) {
+                logger.error("Failed to delete lock file {}; this file should be cleaned up manually", lockFile);
+            }
+        }
+    }
+
+    private static List<String> getChildProcesses(final String ppid) throws IOException {
+        final Process proc = Runtime.getRuntime().exec(new String[]{"ps", "-o", "pid", "--no-headers", "--ppid", ppid});
+        final List<String> childPids = new ArrayList<>();
+        try (final InputStream in = proc.getInputStream();
+             final BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                childPids.add(line.trim());
+            }
+        }
+
+        return childPids;
+    }
+
+    private void killProcessTree(final String pid, final Logger logger) throws IOException {
+        logger.debug("Killing Process Tree for PID {}", pid);
+
+        final List<String> children = getChildProcesses(pid);
+        logger.debug("Children of PID {}: {}", new Object[]{pid, children});
+
+        for (final String childPid : children) {
+            killProcessTree(childPid, logger);
+        }
+
+        Runtime.getRuntime().exec(new String[]{"kill", "-9", pid});
+    }
+
+    public static boolean isAlive(final Process process) {
+        try {
+            process.exitValue();
+            return false;
+        } catch (final IllegalStateException | IllegalThreadStateException itse) {
+            return true;
+        }
+    }
+
+    private String getHostname() {
+        String hostname = "Unknown Host";
+        String ip = "Unknown IP Address";
+        try {
+            final InetAddress localhost = InetAddress.getLocalHost();
+            hostname = localhost.getHostName();
+            ip = localhost.getHostAddress();
+        } catch (final Exception e) {
+            defaultLogger.warn("Failed to obtain hostname for notification due to:", e);
+        }
+
+        return hostname + " (" + ip + ")";
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void start() throws IOException, InterruptedException {
+        final Integer port = getCurrentPort(cmdLogger);
+        if (port != null) {
+            cmdLogger.info("Apache NiFi Registry is already running, listening to Bootstrap on port " + port);
+            return;
+        }
+
+        final File prevLockFile = getLockFile(cmdLogger);
+        if (prevLockFile.exists() && !prevLockFile.delete()) {
+            cmdLogger.warn("Failed to delete previous lock file {}; this file should be cleaned up manually", prevLockFile);
+        }
+
+        final ProcessBuilder builder = new ProcessBuilder();
+
+        if (!bootstrapConfigFile.exists()) {
+            throw new FileNotFoundException(bootstrapConfigFile.getAbsolutePath());
+        }
+
+        final Properties properties = new Properties();
+        try (final FileInputStream fis = new FileInputStream(bootstrapConfigFile)) {
+            properties.load(fis);
+        }
+
+        final Map<String, String> props = new HashMap<>();
+        props.putAll((Map) properties);
+
+        final String specifiedWorkingDir = props.get("working.dir");
+        if (specifiedWorkingDir != null) {
+            builder.directory(new File(specifiedWorkingDir));
+        }
+
+        final File bootstrapConfigAbsoluteFile = bootstrapConfigFile.getAbsoluteFile();
+        final File binDir = bootstrapConfigAbsoluteFile.getParentFile();
+        final File workingDir = binDir.getParentFile();
+
+        if (specifiedWorkingDir == null) {
+            builder.directory(workingDir);
+        }
+
+        final String nifiRegistryLogDir = replaceNull(System.getProperty("org.apache.nifi.registry.bootstrap.config.log.dir"), DEFAULT_LOG_DIR).trim();
+
+        final String libFilename = replaceNull(props.get("lib.dir"), "./lib").trim();
+        File libDir = getFile(libFilename, workingDir);
+        File libSharedDir = getFile(libFilename + "/shared", workingDir);
+
+        final String confFilename = replaceNull(props.get("conf.dir"), "./conf").trim();
+        File confDir = getFile(confFilename, workingDir);
+
+        String nifiRegistryPropsFilename = props.get("props.file");
+        if (nifiRegistryPropsFilename == null) {
+            if (confDir.exists()) {
+                nifiRegistryPropsFilename = new File(confDir, "nifi-registry.properties").getAbsolutePath();
+            } else {
+                nifiRegistryPropsFilename = DEFAULT_CONFIG_FILE;
+            }
+        }
+
+        nifiRegistryPropsFilename = nifiRegistryPropsFilename.trim();
+
+        final List<String> javaAdditionalArgs = new ArrayList<>();
+        for (final Map.Entry<String, String> entry : props.entrySet()) {
+            final String key = entry.getKey();
+            final String value = entry.getValue();
+
+            if (key.startsWith("java.arg")) {
+                javaAdditionalArgs.add(value);
+            }
+        }
+
+        final File[] libSharedFiles = libSharedDir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(final File dir, final String filename) {
+                return filename.toLowerCase().endsWith(".jar");
+            }
+        });
+
+        if (libSharedFiles == null || libSharedFiles.length == 0) {
+            throw new RuntimeException("Could not find lib shared directory at " + libSharedDir.getAbsolutePath());
+        }
+
+        final File[] libFiles = libDir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(final File dir, final String filename) {
+                return filename.toLowerCase().endsWith(".jar");
+            }
+        });
+
+        if (libFiles == null || libFiles.length == 0) {
+            throw new RuntimeException("Could not find lib directory at " + libDir.getAbsolutePath());
+        }
+
+        final File[] confFiles = confDir.listFiles();
+        if (confFiles == null || confFiles.length == 0) {
+            throw new RuntimeException("Could not find conf directory at " + confDir.getAbsolutePath());
+        }
+
+        final List<String> cpFiles = new ArrayList<>(confFiles.length + libFiles.length + libSharedFiles.length);
+        cpFiles.add(confDir.getAbsolutePath());
+        for (final File file : libSharedFiles) {
+            cpFiles.add(file.getAbsolutePath());
+        }
+        for (final File file : libFiles) {
+            cpFiles.add(file.getAbsolutePath());
+        }
+
+        final StringBuilder classPathBuilder = new StringBuilder();
+        for (int i = 0; i < cpFiles.size(); i++) {
+            final String filename = cpFiles.get(i);
+            classPathBuilder.append(filename);
+            if (i < cpFiles.size() - 1) {
+                classPathBuilder.append(File.pathSeparatorChar);
+            }
+        }
+
+        final String classPath = classPathBuilder.toString();
+        String javaCmd = props.get("java");
+        if (javaCmd == null) {
+            javaCmd = DEFAULT_JAVA_CMD;
+        }
+        if (javaCmd.equals(DEFAULT_JAVA_CMD)) {
+            String javaHome = System.getenv("JAVA_HOME");
+            if (javaHome != null) {
+                String fileExtension = isWindows() ? ".exe" : "";
+                File javaFile = new File(javaHome + File.separatorChar + "bin"
+                        + File.separatorChar + "java" + fileExtension);
+                if (javaFile.exists() && javaFile.canExecute()) {
+                    javaCmd = javaFile.getAbsolutePath();
+                }
+            }
+        }
+
+        final NiFiRegistryListener listener = new NiFiRegistryListener();
+        final int listenPort = listener.start(this);
+
+        final List<String> cmd = new ArrayList<>();
+
+        cmd.add(javaCmd);
+        cmd.add("-classpath");
+        cmd.add(classPath);
+        cmd.addAll(javaAdditionalArgs);
+        cmd.add("-Dnifi.registry.properties.file.path=" + nifiRegistryPropsFilename);
+        cmd.add("-Dnifi.registry.bootstrap.listen.port=" + listenPort);
+        cmd.add("-Dapp=NiFiRegistry");
+        cmd.add("-Dorg.apache.nifi.registry.bootstrap.config.log.dir=" + nifiRegistryLogDir);
+        cmd.add("org.apache.nifi.registry.NiFiRegistry");
+        if (props.containsKey(NIFI_REGISTRY_BOOTSTRAP_SENSITIVE_KEY) && !StringUtils.isBlank(props.get(NIFI_REGISTRY_BOOTSTRAP_SENSITIVE_KEY))) {
+            Path sensitiveKeyFile = Paths.get(confDir+"/sensitive.key");
+
+            try {
+                // Initially create file with the empty permission set (so nobody can get a file descriptor on it):
+                Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();
+                FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
+                sensitiveKeyFile = Files.createFile(sensitiveKeyFile, attr);
+
+                // Then, once created, add owner-only rights:
+                perms.add(PosixFilePermission.OWNER_WRITE);
+                perms.add(PosixFilePermission.OWNER_READ);
+                attr = PosixFilePermissions.asFileAttribute(perms);
+                Files.setPosixFilePermissions(sensitiveKeyFile, perms);
+
+            } catch (final FileAlreadyExistsException  faee) {
+                cmdLogger.error("The sensitive.key file {} already exists. That shouldn't have been. Aborting.", sensitiveKeyFile);
+                System.exit(1);
+            } catch (final Exception e) {
+                cmdLogger.error("Other failure relating to setting permissions on {}. "
+                        + "(so that only the owner can read it). "
+                        + "This is fatal to the bootstrap process for security reasons. Exception was: {}", sensitiveKeyFile, e);
+                System.exit(1);
+            }
+
+            BufferedWriter sensitiveKeyWriter = Files.newBufferedWriter(sensitiveKeyFile, StandardCharsets.UTF_8);
+            sensitiveKeyWriter.write(props.get(NIFI_REGISTRY_BOOTSTRAP_SENSITIVE_KEY));
+            sensitiveKeyWriter.close();
+            cmd.add("-K " + sensitiveKeyFile.toFile().getAbsolutePath());
+        }
+
+        builder.command(cmd);
+
+        final StringBuilder cmdBuilder = new StringBuilder();
+        for (final String s : cmd) {
+            cmdBuilder.append(s).append(" ");
+        }
+
+        cmdLogger.info("Starting Apache NiFi Registry...");
+        cmdLogger.info("Working Directory: {}", workingDir.getAbsolutePath());
+        cmdLogger.info("Command: {}", cmdBuilder.toString());
+
+        String gracefulShutdown = props.get(GRACEFUL_SHUTDOWN_PROP);
+        if (gracefulShutdown == null) {
+            gracefulShutdown = DEFAULT_GRACEFUL_SHUTDOWN_VALUE;
+        }
+
+        final int gracefulShutdownSeconds;
+        try {
+            gracefulShutdownSeconds = Integer.parseInt(gracefulShutdown);
+        } catch (final NumberFormatException nfe) {
+            throw new NumberFormatException("The '" + GRACEFUL_SHUTDOWN_PROP + "' property in Bootstrap Config File "
+                    + bootstrapConfigAbsoluteFile.getAbsolutePath() + " has an invalid value. Must be a non-negative integer");
+        }
+
+        if (gracefulShutdownSeconds < 0) {
+            throw new NumberFormatException("The '" + GRACEFUL_SHUTDOWN_PROP + "' property in Bootstrap Config File "
+                    + bootstrapConfigAbsoluteFile.getAbsolutePath() + " has an invalid value. Must be a non-negative integer");
+        }
+
+        Process process = builder.start();
+        handleLogging(process);
+        Long pid = OSUtils.getProcessId(process, cmdLogger);
+        if (pid == null) {
+            cmdLogger.warn("Launched Apache NiFi Registry but could not determined the Process ID");
+        } else {
+            nifiRegistryPid = pid;
+            final Properties pidProperties = new Properties();
+            pidProperties.setProperty(PID_KEY, String.valueOf(nifiRegistryPid));
+            savePidProperties(pidProperties, cmdLogger);
+            cmdLogger.info("Launched Apache NiFi Registry with Process ID " + pid);
+        }
+
+        shutdownHook = new ShutdownHook(process, this, secretKey, gracefulShutdownSeconds, loggingExecutor);
+        final Runtime runtime = Runtime.getRuntime();
+        runtime.addShutdownHook(shutdownHook);
+
+        final String hostname = getHostname();
+        final SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS");
+        String now = sdf.format(System.currentTimeMillis());
+        String user = System.getProperty("user.name");
+        if (user == null || user.trim().isEmpty()) {
+            user = "Unknown User";
+        }
+
+        while (true) {
+            final boolean alive = isAlive(process);
+
+            if (alive) {
+                try {
+                    Thread.sleep(1000L);
+                } catch (final InterruptedException ie) {
+                }
+            } else {
+                try {
+                    runtime.removeShutdownHook(shutdownHook);
+                } catch (final IllegalStateException ise) {
+                    // happens when already shutting down
+                }
+
+                now = sdf.format(System.currentTimeMillis());
+                if (autoRestartNiFiRegistry) {
+                    final File statusFile = getStatusFile(defaultLogger);
+                    if (!statusFile.exists()) {
+                        defaultLogger.info("Status File no longer exists. Will not restart NiFi Registry ");
+                        return;
+                    }
+
+                    final File lockFile = getLockFile(defaultLogger);
+                    if (lockFile.exists()) {
+                        defaultLogger.info("A shutdown was initiated. Will not restart NiFi Registry ");
+                        return;
+                    }
+
+                    final boolean previouslyStarted = getNifiRegistryStarted();
+                    if (!previouslyStarted) {
+                        defaultLogger.info("NiFi Registry never started. Will not restart NiFi Registry ");
+                        return;
+                    } else {
+                        setNiFiRegistryStarted(false);
+                    }
+
+                    defaultLogger.warn("Apache NiFi Registry appears to have died. Restarting...");
+                    process = builder.start();
+                    handleLogging(process);
+
+                    pid = OSUtils.getProcessId(process, defaultLogger);
+                    if (pid == null) {
+                        cmdLogger.warn("Launched Apache NiFi Registry but could not obtain the Process ID");
+                    } else {
+                        nifiRegistryPid = pid;
+                        final Properties pidProperties = new Properties();
+                        pidProperties.setProperty(PID_KEY, String.valueOf(nifiRegistryPid));
+                        savePidProperties(pidProperties, defaultLogger);
+                        cmdLogger.info("Launched Apache NiFi Registry with Process ID " + pid);
+                    }
+
+                    shutdownHook = new ShutdownHook(process, this, secretKey, gracefulShutdownSeconds, loggingExecutor);
+                    runtime.addShutdownHook(shutdownHook);
+
+                    final boolean started = waitForStart();
+
+                    if (started) {
+                        defaultLogger.info("Successfully started Apache NiFi Registry {}", (pid == null ? "" : " with PID " + pid));
+                    } else {
+                        defaultLogger.error("Apache NiFi Registry does not appear to have started");
+                    }
+                } else {
+                    return;
+                }
+            }
+        }
+    }
+
+    private void handleLogging(final Process process) {
+        final Set<Future<?>> existingFutures = loggingFutures;
+        if (existingFutures != null) {
+            for (final Future<?> future : existingFutures) {
+                future.cancel(false);
+            }
+        }
+
+        final Future<?> stdOutFuture = loggingExecutor.submit(new Runnable() {
+            @Override
+            public void run() {
+                final Logger stdOutLogger = LoggerFactory.getLogger("org.apache.nifi.registry.StdOut");
+                final InputStream in = process.getInputStream();
+                try (final BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        stdOutLogger.info(line);
+                    }
+                } catch (IOException e) {
+                    defaultLogger.error("Failed to read from NiFi Registry's Standard Out stream", e);
+                }
+            }
+        });
+
+        final Future<?> stdErrFuture = loggingExecutor.submit(new Runnable() {
+            @Override
+            public void run() {
+                final Logger stdErrLogger = LoggerFactory.getLogger("org.apache.nifi.registry.StdErr");
+                final InputStream in = process.getErrorStream();
+                try (final BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        stdErrLogger.error(line);
+                    }
+                } catch (IOException e) {
+                    defaultLogger.error("Failed to read from NiFi Registry's Standard Error stream", e);
+                }
+            }
+        });
+
+        final Set<Future<?>> futures = new HashSet<>();
+        futures.add(stdOutFuture);
+        futures.add(stdErrFuture);
+        this.loggingFutures = futures;
+    }
+
+
+    private boolean isWindows() {
+        final String osName = System.getProperty("os.name");
+        return osName != null && osName.toLowerCase().contains("win");
+    }
+
+    private boolean waitForStart() {
+        lock.lock();
+        try {
+            final long startTime = System.nanoTime();
+
+            while (ccPort < 1) {
+                try {
+                    startupCondition.await(1, TimeUnit.SECONDS);
+                } catch (final InterruptedException ie) {
+                    return false;
+                }
+
+                final long waitNanos = System.nanoTime() - startTime;
+                final long waitSeconds = TimeUnit.NANOSECONDS.toSeconds(waitNanos);
+                if (waitSeconds > STARTUP_WAIT_SECONDS) {
+                    return false;
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+        return true;
+    }
+
+    private File getFile(final String filename, final File workingDir) {
+        File file = new File(filename);
+        if (!file.isAbsolute()) {
+            file = new File(workingDir, filename);
+        }
+
+        return file;
+    }
+
+    private String replaceNull(final String value, final String replacement) {
+        return (value == null) ? replacement : value;
+    }
+
+    void setAutoRestartNiFiRegistry(final boolean restart) {
+        this.autoRestartNiFiRegistry = restart;
+    }
+
+    void setNiFiRegistryCommandControlPort(final int port, final String secretKey) throws IOException {
+        this.ccPort = port;
+        this.secretKey = secretKey;
+
+        if (shutdownHook != null) {
+            shutdownHook.setSecretKey(secretKey);
+        }
+
+        final File statusFile = getStatusFile(defaultLogger);
+
+        final Properties nifiProps = new Properties();
+        if (nifiRegistryPid != -1) {
+            nifiProps.setProperty(PID_KEY, String.valueOf(nifiRegistryPid));
+        }
+        nifiProps.setProperty("port", String.valueOf(ccPort));
+        nifiProps.setProperty("secret.key", secretKey);
+
+        try {
+            savePidProperties(nifiProps, defaultLogger);
+        } catch (final IOException ioe) {
+            defaultLogger.warn("Apache NiFi Registry has started but failed to persist NiFi Registry Port information to {} due to {}", new Object[]{statusFile.getAbsolutePath(), ioe});
+        }
+
+        defaultLogger.info("Apache NiFi Registry now running and listening for Bootstrap requests on port {}", port);
+    }
+
+    int getNiFiRegistryCommandControlPort() {
+        return this.ccPort;
+    }
+
+    void setNiFiRegistryStarted(final boolean nifiStarted) {
+        startedLock.lock();
+        try {
+            this.nifiRegistryStarted = nifiStarted;
+        } finally {
+            startedLock.unlock();
+        }
+    }
+
+    boolean getNifiRegistryStarted() {
+        startedLock.lock();
+        try {
+            return nifiRegistryStarted;
+        } finally {
+            startedLock.unlock();
+        }
+    }
+
+    private static class Status {
+
+        private final Integer port;
+        private final String pid;
+
+        private final Boolean respondingToPing;
+        private final Boolean processRunning;
+
+        public Status(final Integer port, final String pid, final Boolean respondingToPing, final Boolean processRunning) {
+            this.port = port;
+            this.pid = pid;
+            this.respondingToPing = respondingToPing;
+            this.processRunning = processRunning;
+        }
+
+        public String getPid() {
+            return pid;
+        }
+
+        public Integer getPort() {
+            return port;
+        }
+
+        public boolean isRespondingToPing() {
+            return Boolean.TRUE.equals(respondingToPing);
+        }
+
+        public boolean isProcessRunning() {
+            return Boolean.TRUE.equals(processRunning);
+        }
+    }
+}

--- a/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/ShutdownHook.java
+++ b/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/ShutdownHook.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.bootstrap;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ShutdownHook extends Thread {
+
+    private final Process nifiRegistryProcess;
+    private final RunNiFiRegistry runner;
+    private final int gracefulShutdownSeconds;
+    private final ExecutorService executor;
+
+    private volatile String secretKey;
+
+    public ShutdownHook(final Process nifiRegistryProcess, final RunNiFiRegistry runner, final String secretKey, final int gracefulShutdownSeconds, final ExecutorService executor) {
+        this.nifiRegistryProcess = nifiRegistryProcess;
+        this.runner = runner;
+        this.secretKey = secretKey;
+        this.gracefulShutdownSeconds = gracefulShutdownSeconds;
+        this.executor = executor;
+    }
+
+    void setSecretKey(final String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    @Override
+    public void run() {
+        executor.shutdown();
+        runner.setAutoRestartNiFiRegistry(false);
+        final int ccPort = runner.getNiFiRegistryCommandControlPort();
+        if (ccPort > 0) {
+            System.out.println("Initiating Shutdown of NiFi Registry...");
+
+            try {
+                final Socket socket = new Socket("localhost", ccPort);
+                final OutputStream out = socket.getOutputStream();
+                out.write(("SHUTDOWN " + secretKey + "\n").getBytes(StandardCharsets.UTF_8));
+                out.flush();
+
+                socket.close();
+            } catch (final IOException ioe) {
+                System.out.println("Failed to Shutdown NiFi Registry due to " + ioe);
+            }
+        }
+
+        runner.notifyStop();
+        System.out.println("Waiting for Apache NiFi Registry to finish shutting down...");
+        final long startWait = System.nanoTime();
+        while (RunNiFiRegistry.isAlive(nifiRegistryProcess)) {
+            final long waitNanos = System.nanoTime() - startWait;
+            final long waitSeconds = TimeUnit.NANOSECONDS.toSeconds(waitNanos);
+            if (waitSeconds >= gracefulShutdownSeconds && gracefulShutdownSeconds > 0) {
+                if (RunNiFiRegistry.isAlive(nifiRegistryProcess)) {
+                    System.out.println("NiFi Registry has not finished shutting down after " + gracefulShutdownSeconds + " seconds. Killing process.");
+                    nifiRegistryProcess.destroy();
+                }
+                break;
+            } else {
+                try {
+                    Thread.sleep(1000L);
+                } catch (final InterruptedException ie) {
+                }
+            }
+        }
+
+        try {
+            final File statusFile = runner.getStatusFile();
+            if (!statusFile.delete()) {
+                System.err.println("Failed to delete status file " + statusFile.getAbsolutePath() + "; this file should be cleaned up manually");
+            }
+        }catch (IOException ex){
+            System.err.println("Failed to retrieve status file " + ex);
+        }
+    }
+}

--- a/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/exception/InvalidCommandException.java
+++ b/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/exception/InvalidCommandException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.bootstrap.exception;
+
+public class InvalidCommandException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidCommandException() {
+        super();
+    }
+
+    public InvalidCommandException(final String message) {
+        super(message);
+    }
+
+    public InvalidCommandException(final Throwable t) {
+        super(t);
+    }
+
+    public InvalidCommandException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/util/LimitingInputStream.java
+++ b/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/util/LimitingInputStream.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.bootstrap.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class LimitingInputStream extends InputStream {
+
+    private final InputStream in;
+    private final long limit;
+    private long bytesRead = 0;
+
+    public LimitingInputStream(final InputStream in, final long limit) {
+        this.in = in;
+        this.limit = limit;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (bytesRead >= limit) {
+            return -1;
+        }
+
+        final int val = in.read();
+        if (val > -1) {
+            bytesRead++;
+        }
+        return val;
+    }
+
+    @Override
+    public int read(final byte[] b) throws IOException {
+        if (bytesRead >= limit) {
+            return -1;
+        }
+
+        final int maxToRead = (int) Math.min(b.length, limit - bytesRead);
+
+        final int val = in.read(b, 0, maxToRead);
+        if (val > 0) {
+            bytesRead += val;
+        }
+        return val;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (bytesRead >= limit) {
+            return -1;
+        }
+
+        final int maxToRead = (int) Math.min(len, limit - bytesRead);
+
+        final int val = in.read(b, off, maxToRead);
+        if (val > 0) {
+            bytesRead += val;
+        }
+        return val;
+    }
+
+    @Override
+    public long skip(final long n) throws IOException {
+        final long skipped = in.skip(Math.min(n, limit - bytesRead));
+        bytesRead += skipped;
+        return skipped;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return in.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        in.mark(readlimit);
+    }
+
+    @Override
+    public boolean markSupported() {
+        return in.markSupported();
+    }
+
+    @Override
+    public void reset() throws IOException {
+        in.reset();
+    }
+}

--- a/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/util/OSUtils.java
+++ b/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/util/OSUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.registry.bootstrap.util;
+
+import java.lang.reflect.Field;
+
+import org.slf4j.Logger;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.WinNT;
+
+/**
+ * OS specific utilities with generic method interfaces
+ */
+public final class OSUtils {
+    /**
+     * @param process NiFi Process Reference
+     * @param logger  Logger Reference for Debug
+     * @return        Returns pid or null in-case pid could not be determined
+     * This method takes {@link Process} and {@link Logger} and returns
+     * the platform specific ProcessId for Unix like systems, a.k.a <b>pid</b>
+     * In-case it fails to determine the pid, it will return Null.
+     * Purpose for the Logger is to log any interaction for debugging.
+     */
+    private static Long getUnicesPid(final Process process, final Logger logger) {
+        try {
+            final Class<?> procClass = process.getClass();
+            final Field pidField = procClass.getDeclaredField("pid");
+            pidField.setAccessible(true);
+            final Object pidObject = pidField.get(process);
+
+            logger.debug("PID Object = {}", pidObject);
+
+            if (pidObject instanceof Number) {
+                return ((Number) pidObject).longValue();
+            }
+            return null;
+        } catch (final IllegalAccessException | NoSuchFieldException nsfe) {
+            logger.debug("Could not find PID for child process due to {}", nsfe);
+            return null;
+        }
+    }
+
+    /**
+     * @param process NiFi Registry Process Reference
+     * @param logger  Logger Reference for Debug
+     * @return        Returns pid or null in-case pid could not be determined
+     * This method takes {@link Process} and {@link Logger} and returns
+     * the platform specific Handle for Win32 Systems, a.k.a <b>pid</b>
+     * In-case it fails to determine the pid, it will return Null.
+     * Purpose for the Logger is to log any interaction for debugging.
+     */
+    private static Long getWindowsProcessId(final Process process, final Logger logger) {
+        /* determine the pid on windows plattforms */
+        try {
+            Field f = process.getClass().getDeclaredField("handle");
+            f.setAccessible(true);
+            long handl = f.getLong(process);
+
+            Kernel32 kernel = Kernel32.INSTANCE;
+            WinNT.HANDLE handle = new WinNT.HANDLE();
+            handle.setPointer(Pointer.createConstant(handl));
+            int ret = kernel.GetProcessId(handle);
+            logger.debug("Detected pid: {}", ret);
+            return Long.valueOf(ret);
+        } catch (final IllegalAccessException | NoSuchFieldException nsfe) {
+            logger.debug("Could not find PID for child process due to {}", nsfe);
+        }
+        return null;
+    }
+
+    /**
+     * @param process NiFi Process Reference
+     * @param logger  Logger Reference for Debug
+     * @return        Returns pid or null in-case pid could not be determined
+     * This method takes {@link Process} and {@link Logger} and returns
+     * the platform specific ProcessId for Unix like systems or Handle for Win32 Systems, a.k.a <b>pid</b>
+     * In-case it fails to determine the pid, it will return Null.
+     * Purpose for the Logger is to log any interaction for debugging.
+     */
+    public static Long getProcessId(final Process process, final Logger logger) {
+        if (process.getClass().getName().equals("java.lang.UNIXProcess")) {
+            return getUnicesPid(process, logger);
+        } else if (process.getClass().getName().equals("java.lang.Win32Process")
+                || process.getClass().getName().equals("java.lang.ProcessImpl")) {
+            return getWindowsProcessId(process, logger);
+        }
+
+        return null;
+    }
+
+}

--- a/nifi-registry-resources/src/main/resources/bin/nifi-registry-env.sh
+++ b/nifi-registry-resources/src/main/resources/bin/nifi-registry-env.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# The java implementation to use.
+#export JAVA_HOME=/usr/java/jdk1.8.0/
+
+export NIFI_REGISTRY_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
+
+#The directory for the NiFi Registry pid file
+export NIFI_REGISTRY_PID_DIR="${NIFI_REGISTRY_HOME}/run"
+
+#The directory for NiFi Registry log files
+export NIFI_REGISTRY_LOG_DIR="${NIFI_REGISTRY_HOME}/logs"

--- a/nifi-registry-resources/src/main/resources/bin/nifi-registry.sh
+++ b/nifi-registry-resources/src/main/resources/bin/nifi-registry.sh
@@ -15,11 +15,36 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-
 # Script structure inspired from Apache Karaf and other Apache projects with similar startup approaches
 
-NIFI_REGISTRY_HOME=`cd $(dirname "$0") && cd .. && pwd`
-PROGNAME=`basename "$0"`
+# Discover the path of the file
+
+
+# Since MacOS X, FreeBSD and some other systems lack gnu readlink, we use a more portable
+# approach based on following StackOverflow comment http://stackoverflow.com/a/1116890/888876
+
+TARGET_FILE=$0
+
+cd $(dirname $TARGET_FILE)
+TARGET_FILE=$(basename $TARGET_FILE)
+
+# Iterate down a (possible) chain of symlinks
+while [ -L "$TARGET_FILE" ]
+do
+    TARGET_FILE=$(readlink $TARGET_FILE)
+    cd $(dirname $TARGET_FILE)
+    TARGET_FILE=$(basename $TARGET_FILE)
+done
+
+# Compute the canonicalized name by finding the physical path
+# for the directory we're in and appending the target file.
+PHYS_DIR=$(pwd -P)
+
+SCRIPT_DIR=$PHYS_DIR
+PROGNAME=$(basename "$0")
+
+. "${SCRIPT_DIR}/nifi-registry-env.sh"
+
 
 
 warn() {
@@ -37,7 +62,7 @@ detectOS() {
     aix=false;
     os400=false;
     darwin=false;
-    case "`uname`" in
+    case "$(uname)" in
         CYGWIN*)
             cygwin=true
             ;;
@@ -48,39 +73,45 @@ detectOS() {
             os400=true
             ;;
         Darwin)
-                darwin=true
-                ;;
+            darwin=true
+            ;;
     esac
     # For AIX, set an environment variable
-    if $aix; then
+    if ${aix}; then
          export LDR_CNTRL=MAXDATA=0xB0000000@DSA
-         echo $LDR_CNTRL
+         echo ${LDR_CNTRL}
+    fi
+    # In addition to those, go around the linux space and query the widely
+    # adopted /etc/os-release to detect linux variants
+    if [ -f /etc/os-release ]
+    then
+        source /etc/os-release
     fi
 }
 
 unlimitFD() {
     # Use the maximum available, or set MAX_FD != -1 to use that
-    if [ "x$MAX_FD" = "x" ]; then
+    if [ "x${MAX_FD}" = "x" ]; then
         MAX_FD="maximum"
     fi
 
     # Increase the maximum file descriptors if we can
-    if [ "$os400" = "false" ] && [ "$cygwin" = "false" ]; then
-        MAX_FD_LIMIT=`ulimit -H -n`
-        if [ "$MAX_FD_LIMIT" != 'unlimited' ]; then
+    if [ "${os400}" = "false" ] && [ "${cygwin}" = "false" ]; then
+        MAX_FD_LIMIT=$(ulimit -H -n)
+        if [ "${MAX_FD_LIMIT}" != 'unlimited' ]; then
             if [ $? -eq 0 ]; then
-                if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ]; then
+                if [ "${MAX_FD}" = "maximum" -o "${MAX_FD}" = "max" ]; then
                     # use the system max
-                    MAX_FD="$MAX_FD_LIMIT"
+                    MAX_FD="${MAX_FD_LIMIT}"
                 fi
 
-                ulimit -n $MAX_FD > /dev/null
+                ulimit -n ${MAX_FD} > /dev/null
                 # echo "ulimit -n" `ulimit -n`
                 if [ $? -ne 0 ]; then
-                    warn "Could not set maximum file descriptor limit: $MAX_FD"
+                    warn "Could not set maximum file descriptor limit: ${MAX_FD}"
                 fi
             else
-                warn "Could not query system maximum file descriptor limit: $MAX_FD_LIMIT"
+                warn "Could not query system maximum file descriptor limit: ${MAX_FD_LIMIT}"
             fi
         fi
     fi
@@ -91,28 +122,37 @@ unlimitFD() {
 locateJava() {
     # Setup the Java Virtual Machine
     if $cygwin ; then
-        [ -n "$JAVA" ] && JAVA=`cygpath --unix "$JAVA"`
-        [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+        [ -n "${JAVA}" ] && JAVA=$(cygpath --unix "${JAVA}")
+        [ -n "${JAVA_HOME}" ] && JAVA_HOME=$(cygpath --unix "${JAVA_HOME}")
     fi
 
-    if [ "x$JAVA" = "x" ] && [ -r /etc/gentoo-release ] ; then
-        JAVA_HOME=`java-config --jre-home`
+    if [ "x${JAVA}" = "x" ] && [ -r /etc/gentoo-release ] ; then
+        JAVA_HOME=$(java-config --jre-home)
     fi
-    if [ "x$JAVA" = "x" ]; then
-        if [ "x$JAVA_HOME" != "x" ]; then
-            if [ ! -d "$JAVA_HOME" ]; then
-                die "JAVA_HOME is not valid: $JAVA_HOME"
+    if [ "x${JAVA}" = "x" ]; then
+        if [ "x${JAVA_HOME}" != "x" ]; then
+            if [ ! -d "${JAVA_HOME}" ]; then
+                die "JAVA_HOME is not valid: ${JAVA_HOME}"
             fi
-            JAVA="$JAVA_HOME/bin/java"
+            JAVA="${JAVA_HOME}/bin/java"
         else
             warn "JAVA_HOME not set; results may vary"
-            JAVA=`type java`
-            JAVA=`expr "$JAVA" : '.* \(/.*\)$'`
-            if [ "x$JAVA" = "x" ]; then
+            JAVA=$(type java)
+            JAVA=$(expr "${JAVA}" : '.* \(/.*\)$')
+            if [ "x${JAVA}" = "x" ]; then
                 die "java command not found"
             fi
         fi
     fi
+    # if command is env, attempt to add more to the classpath
+    if [ "$1" = "env" ]; then
+        [ "x${TOOLS_JAR}" =  "x" ] && [ -n "${JAVA_HOME}" ] && TOOLS_JAR=$(find -H "${JAVA_HOME}" -name "tools.jar")
+        [ "x${TOOLS_JAR}" =  "x" ] && [ -n "${JAVA_HOME}" ] && TOOLS_JAR=$(find -H "${JAVA_HOME}" -name "classes.jar")
+        if [ "x${TOOLS_JAR}" =  "x" ]; then
+             warn "Could not locate tools.jar or classes.jar. Please set manually to avail all command features."
+        fi
+    fi
+
 }
 
 init() {
@@ -123,67 +163,168 @@ init() {
     unlimitFD
 
     # Locate the Java VM to execute
-    locateJava
+    locateJava "$1"
 }
 
 
 install() {
-        SVC_NAME=nifi-registry
-        if [ "x$2" != "x" ] ; then
-                SVC_NAME=$2
-        fi
+    detectOS
 
-        SVC_FILE=/etc/init.d/$SVC_NAME
-        cp $0 $SVC_FILE
-        sed -i s:NIFI_REGISTRY_HOME=.*:NIFI_REGISTRY_HOME="$NIFI_REGISTRY_HOME": $SVC_FILE
-        sed -i s:PROGNAME=.*:PROGNAME=$(basename "$0"): $SVC_FILE
-        rm -f /etc/rc2.d/S65${SVC_NAME}
-        ln -s /etc/init.d/$SVC_NAME /etc/rc2.d/S65${SVC_NAME}
-        rm -f /etc/rc2.d/K65${SVC_NAME}
-        ln -s /etc/init.d/$SVC_NAME /etc/rc2.d/K65${SVC_NAME}
-        echo Service $SVC_NAME installed
+    if [ "${darwin}" = "true"  ] || [ "${cygwin}" = "true" ]; then
+        echo 'Installing Apache NiFi Registry as a service is not supported on OS X or Cygwin.'
+        exit 1
+    fi
+
+    SVC_NAME=nifi-registry
+    if [ "x$2" != "x" ] ; then
+        SVC_NAME=$2
+    fi
+
+    # since systemd seems to honour /etc/init.d we don't still create native systemd services
+    # yet...
+    initd_dir='/etc/init.d'
+    SVC_FILE="${initd_dir}/${SVC_NAME}"
+
+    if [ ! -w  "${initd_dir}" ]; then
+        echo "Current user does not have write permissions to ${initd_dir}. Cannot install NiFi Registry as a service."
+        exit 1
+    fi
+
+# Create the init script, overwriting anything currently present
+cat <<SERVICEDESCRIPTOR > ${SVC_FILE}
+#!/bin/sh
+
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# chkconfig: 2345 20 80
+# description: Apache NiFi Registry is a complementary application that provides a central location for storage and management of shared resources across one or more instances of NiFi and/or MiNiFi.
+
+# Make use of the configured NIFI_REGISTRY_HOME directory and pass service requests to the nifi-registry.sh executable
+NIFI_REGISTRY_HOME=${NIFI_REGISTRY_HOME}
+bin_dir=\${NIFI_REGISTRY_HOME}/bin
+nifi_registry_executable=\${bin_dir}/nifi-registry.sh
+
+\${nifi_registry_executable} "\$@"
+SERVICEDESCRIPTOR
+
+    if [ ! -f "${SVC_FILE}" ]; then
+        echo "Could not create service file ${SVC_FILE}"
+        exit 1
+    fi
+
+    # Provide the user execute access on the file
+    chmod u+x ${SVC_FILE}
+
+
+    # If SLES or OpenSuse...
+    if [ "${ID}" = "opensuse" ] || [ "${ID}" = "sles" ]; then
+        rm -f "/etc/rc.d/rc2.d/S65${SVC_NAME}"
+        ln -s "/etc/init.d/${SVC_NAME}" "/etc/rc.d/rc2.d/S65${SVC_NAME}" || { echo "Could not create link /etc/rc.d/rc2.d/S65${SVC_NAME}"; exit 1; }
+        rm -f "/etc/rc.d/rc2.d/K65${SVC_NAME}"
+        ln -s "/etc/init.d/${SVC_NAME}" "/etc/rc.d/rc2.d/K65${SVC_NAME}" || { echo "Could not create link /etc/rc.d/rc2.d/K65${SVC_NAME}"; exit 1; }
+        echo "Service ${SVC_NAME} installed"
+    # Anything other fallback to the old approach
+    else
+        rm -f "/etc/rc2.d/S65${SVC_NAME}"
+        ln -s "/etc/init.d/${SVC_NAME}" "/etc/rc2.d/S65${SVC_NAME}" || { echo "Could not create link /etc/rc2.d/S65${SVC_NAME}"; exit 1; }
+        rm -f "/etc/rc2.d/K65${SVC_NAME}"
+        ln -s "/etc/init.d/${SVC_NAME}" "/etc/rc2.d/K65${SVC_NAME}" || { echo "Could not create link /etc/rc2.d/K65${SVC_NAME}"; exit 1; }
+        echo "Service ${SVC_NAME} installed"
+    fi
 }
 
-
 run() {
-    BOOTSTRAP_CONF="$NIFI_REGISTRY_HOME/conf/bootstrap.conf";
+    BOOTSTRAP_CONF_DIR="${NIFI_REGISTRY_HOME}/conf"
+    BOOTSTRAP_CONF="${BOOTSTRAP_CONF_DIR}/bootstrap.conf";
+    BOOTSTRAP_LIBS="${NIFI_REGISTRY_HOME}/lib/bootstrap/*"
+    SHARED_LIBS="${NIFI_REGISTRY_HOME}/lib/shared/*"
 
-    run_as=$(grep run.as ${BOOTSTRAP_CONF} | cut -d'=' -f2)
+    run_as_user=$(grep '^\s*run.as' "${BOOTSTRAP_CONF}" | cut -d'=' -f2)
+    # If the run as user is the same as that starting the process, ignore this configuration
+    if [ "${run_as_user}" = "$(whoami)" ]; then
+        unset run_as_user
+    fi
 
-    sudo_cmd_prefix=""
     if $cygwin; then
-        if [[ -n "$run_as" ]]; then
+        if [ -n "${run_as_user}" ]; then
             echo "The run.as option is not supported in a Cygwin environment. Exiting."
             exit 1
         fi;
 
-        NIFI_REGISTRY_HOME=`cygpath --path --windows "$NIFI_REGISTRY_HOME"`
-        BOOTSTRAP_CONF=`cygpath --path --windows "$BOOTSTRAP_CONF"`
+        NIFI_REGISTRY_HOME=$(cygpath --path --windows "${NIFI_REGISTRY_HOME}")
+        NIFI_REGISTRY_LOG_DIR=$(cygpath --path --windows "${NIFI_REGISTRY_LOG_DIR}")
+        NIFI_REGISTRY_PID_DIR=$(cygpath --path --windows "${NIFI_REGISTRY_PID_DIR}")
+        BOOTSTRAP_CONF=$(cygpath --path --windows "${BOOTSTRAP_CONF}")
+        BOOTSTRAP_CONF_DIR=$(cygpath --path --windows "${BOOTSTRAP_CONF_DIR}")
+        BOOTSTRAP_LIBS=$(cygpath --path --windows "${BOOTSTRAP_LIBS}")
+        SHARED_LIBS=$(cygpath --path --windows "${SHARED_LIBS}")
+        BOOTSTRAP_CLASSPATH="${BOOTSTRAP_CONF_DIR};${SHARED_LIBS};${BOOTSTRAP_LIBS}"
+        if [ -n "${TOOLS_JAR}" ]; then
+            TOOLS_JAR=$(cygpath --path --windows "${TOOLS_JAR}")
+            BOOTSTRAP_CLASSPATH="${TOOLS_JAR};${BOOTSTRAP_CLASSPATH}"
+        fi
     else
-        if [[ -n "$run_as" ]]; then
-            if id -u "$run_as" >/dev/null 2>&1; then
-                sudo_cmd_prefix="sudo -u ${run_as}"
-            else
-                echo "The specified run.as user ${run_as} does not exist. Exiting."
+        if [ -n "${run_as_user}" ]; then
+            if ! id -u "${run_as_user}" >/dev/null 2>&1; then
+                echo "The specified run.as user ${run_as_user} does not exist. Exiting."
                 exit 1
             fi
         fi;
+        BOOTSTRAP_CLASSPATH="${BOOTSTRAP_CONF_DIR}:${SHARED_LIBS}:${BOOTSTRAP_LIBS}"
+        if [ -n "${TOOLS_JAR}" ]; then
+            BOOTSTRAP_CLASSPATH="${TOOLS_JAR}:${BOOTSTRAP_CLASSPATH}"
+        fi
     fi
 
     echo
-    echo "Java home: $JAVA_HOME"
-    echo "NiFi Registry home: $NIFI_REGISTRY_HOME"
+    echo "Java home: ${JAVA_HOME}"
+    echo "NiFi Registry home: ${NIFI_REGISTRY_HOME}"
     echo
-    echo "Bootstrap Config File: $BOOTSTRAP_CONF"
+    echo "Bootstrap Config File: ${BOOTSTRAP_CONF}"
     echo
 
     # run 'start' in the background because the process will continue to run, monitoring NiFi Registry.
     # all other commands will terminate quickly so want to just wait for them
-    if [ "$1" = "start" ]; then
-        (cd $NIFI_REGISTRY_HOME && ${sudo_cmd_prefix} "$JAVA" -cp "$NIFI_REGISTRY_HOME"/conf/:"$NIFI_REGISTRY_HOME"/lib/* -Xms512m -Xmx1024m -Dorg.apache.nifi.registry.bootstrap.config.file="$BOOTSTRAP_CONF" org.apache.nifi.registry.NiFiRegistry $@ &)
-    else
-        (cd $NIFI_REGISTRY_HOME && ${sudo_cmd_prefix} "$JAVA" -cp "$NIFI_REGISTRY_HOME"/conf/:"$NIFI_REGISTRY_HOME"/lib/* -Xms512m -Xmx1024m -Dorg.apache.nifi.registry.bootstrap.config.file="$BOOTSTRAP_CONF" org.apache.nifi.registry.NiFiRegistry $@)
+
+    #setup directory parameters
+    BOOTSTRAP_LOG_PARAMS="-Dorg.apache.nifi.registry.bootstrap.config.log.dir='${NIFI_REGISTRY_LOG_DIR}'"
+    BOOTSTRAP_PID_PARAMS="-Dorg.apache.nifi.registry.bootstrap.config.pid.dir='${NIFI_REGISTRY_PID_DIR}'"
+    BOOTSTRAP_CONF_PARAMS="-Dorg.apache.nifi.registry.bootstrap.config.file='${BOOTSTRAP_CONF}'"
+
+    BOOTSTRAP_DIR_PARAMS="${BOOTSTRAP_LOG_PARAMS} ${BOOTSTRAP_PID_PARAMS} ${BOOTSTRAP_CONF_PARAMS}"
+
+    run_nifi_registry_cmd="'${JAVA}' -cp '${BOOTSTRAP_CLASSPATH}' -Xms12m -Xmx24m ${BOOTSTRAP_DIR_PARAMS} org.apache.nifi.registry.bootstrap.RunNiFiRegistry $@"
+
+    if [ -n "${run_as_user}" ]; then
+      # Provide SCRIPT_DIR and execute nifi-env for the run.as user command
+      run_nifi_registry_cmd="sudo -u ${run_as_user} sh -c \"SCRIPT_DIR='${SCRIPT_DIR}' && . '${SCRIPT_DIR}/nifi-registry-env.sh' && ${run_nifi_registry_cmd}\""
     fi
+
+    if [ "$1" = "run" ]; then
+      # Use exec to handover PID to RunNiFi java process, instead of forking it as a child process
+      run_nifi_registry_cmd="exec ${run_nifi_registry_cmd}"
+    fi
+
+    if [ "$1" = "start" ]; then
+        ( eval "cd ${NIFI_REGISTRY_HOME} && ${run_nifi_registry_cmd}" & )> /dev/null 1>&-
+    else
+        eval "cd ${NIFI_REGISTRY_HOME} && ${run_nifi_registry_cmd}"
+    fi
+    EXIT_STATUS=$?
 
     # Wait just a bit (3 secs) to wait for the logging to finish and then echo a new-line.
     # We do this to avoid having logs spewed on the console after running the command and then not giving
@@ -193,7 +334,7 @@ run() {
 }
 
 main() {
-    init
+    init "$1"
     run "$@"
 }
 
@@ -202,14 +343,14 @@ case "$1" in
     install)
         install "$@"
         ;;
-    start|stop|run|status|dump)
+    start|stop|run|status|dump|env)
         main "$@"
         ;;
     restart)
         init
-	      run "stop"
-	      run "start"
-	      ;;
+        run "stop"
+        run "start"
+        ;;
     *)
         echo "Usage nifi-registry {start|stop|run|restart|status|dump|install}"
         ;;

--- a/nifi-registry-resources/src/main/resources/conf/logback.xml
+++ b/nifi-registry-resources/src/main/resources/conf/logback.xml
@@ -39,10 +39,55 @@
             <immediateFlush>true</immediateFlush>
         </encoder>
     </appender>
+
+    <appender name="BOOTSTRAP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-bootstrap.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!--
+              For daily rollover, use 'user_%d.log'.
+              For hourly rollover, use 'user_%d{yyyy-MM-dd_HH}.log'.
+              To GZIP rolled files, replace '.log' with '.log.gz'.
+              To ZIP rolled files, replace '.log' with '.log.zip'.
+            -->
+            <fileNamePattern>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-bootstrap_%d.log</fileNamePattern>
+            <!-- keep 5 log files worth of history -->
+            <maxHistory>5</maxHistory>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
+        </encoder>
+    </appender>
     
     <!-- valid logging levels: TRACE, DEBUG, INFO, WARN, ERROR -->
     
     <logger name="org.apache.nifi.registry" level="INFO"/>
+
+    <!--
+        Logger for capturing Bootstrap logs and NiFi Registry's standard error and standard out.
+    -->
+    <logger name="org.apache.nifi.registry.bootstrap" level="INFO" additivity="false">
+        <appender-ref ref="BOOTSTRAP_FILE" />
+    </logger>
+    <logger name="org.apache.nifi.registry.bootstrap.Command" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="BOOTSTRAP_FILE" />
+    </logger>
+
+    <!-- Everything written to NiFi Registry's Standard Out will be logged with the logger org.apache.nifi.StdOut at INFO level -->
+    <logger name="org.apache.nifi.registry.StdOut" level="INFO" additivity="false">
+        <appender-ref ref="BOOTSTRAP_FILE" />
+    </logger>
+
+    <!-- Everything written to NiFi Registry's Standard Error will be logged with the logger org.apache.nifi.StdErr at ERROR level -->
+    <logger name="org.apache.nifi.registry.StdErr" level="ERROR" additivity="false">
+        <appender-ref ref="BOOTSTRAP_FILE" />
+    </logger>
 
     <root level="INFO">
         <appender-ref ref="APP_FILE"/>

--- a/nifi-registry-runtime/pom.xml
+++ b/nifi-registry-runtime/pom.xml
@@ -25,6 +25,11 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi.registry</groupId>
+            <artifactId>nifi-registry-utils</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi.registry</groupId>
             <artifactId>nifi-registry-properties</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
@@ -32,6 +37,10 @@
             <groupId>org.apache.nifi.registry</groupId>
             <artifactId>nifi-registry-jetty</artifactId>
             <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-registry-runtime/src/main/java/org/apache/nifi/registry/BootstrapListener.java
+++ b/nifi-registry-runtime/src/main/java/org/apache/nifi/registry/BootstrapListener.java
@@ -1,0 +1,395 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry;
+
+import org.apache.nifi.registry.util.LimitingInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class BootstrapListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(BootstrapListener.class);
+
+    private final NiFiRegistry nifi;
+    private final int bootstrapPort;
+    private final String secretKey;
+
+    private volatile Listener listener;
+    private volatile ServerSocket serverSocket;
+
+    public BootstrapListener(final NiFiRegistry nifi, final int bootstrapPort) {
+        this.nifi = nifi;
+        this.bootstrapPort = bootstrapPort;
+        secretKey = UUID.randomUUID().toString();
+    }
+
+    public void start() throws IOException {
+        logger.debug("Starting Bootstrap Listener to communicate with Bootstrap Port {}", bootstrapPort);
+
+        serverSocket = new ServerSocket();
+        serverSocket.bind(new InetSocketAddress("localhost", 0));
+        serverSocket.setSoTimeout(2000);
+
+        final int localPort = serverSocket.getLocalPort();
+        logger.info("Started Bootstrap Listener, Listening for incoming requests on port {}", localPort);
+
+        listener = new Listener(serverSocket);
+        final Thread listenThread = new Thread(listener);
+        listenThread.setDaemon(true);
+        listenThread.setName("Listen to Bootstrap");
+        listenThread.start();
+
+        logger.debug("Notifying Bootstrap that local port is {}", localPort);
+        sendCommand("PORT", new String[] { String.valueOf(localPort), secretKey});
+    }
+
+    public void stop() {
+        if (listener != null) {
+            listener.stop();
+        }
+    }
+
+    public void sendStartedStatus(boolean status) throws IOException {
+        logger.debug("Notifying Bootstrap that the status of starting NiFi Registry is {}", status);
+        sendCommand("STARTED", new String[]{ String.valueOf(status) });
+    }
+
+    private void sendCommand(final String command, final String[] args) throws IOException {
+        try (final Socket socket = new Socket()) {
+            socket.setSoTimeout(60000);
+            socket.connect(new InetSocketAddress("localhost", bootstrapPort));
+            socket.setSoTimeout(60000);
+
+            final StringBuilder commandBuilder = new StringBuilder(command);
+            for (final String arg : args) {
+                commandBuilder.append(" ").append(arg);
+            }
+            commandBuilder.append("\n");
+
+            final String commandWithArgs = commandBuilder.toString();
+            logger.debug("Sending command to Bootstrap: " + commandWithArgs);
+
+            final OutputStream out = socket.getOutputStream();
+            out.write((commandWithArgs).getBytes(StandardCharsets.UTF_8));
+            out.flush();
+
+            logger.debug("Awaiting response from Bootstrap...");
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            final String response = reader.readLine();
+            if ("OK".equals(response)) {
+                logger.info("Successfully initiated communication with Bootstrap");
+            } else {
+                logger.error("Failed to communicate with Bootstrap. Bootstrap may be unable to issue or receive commands from NiFi Registry ");
+            }
+        }
+    }
+
+    private class Listener implements Runnable {
+
+        private final ServerSocket serverSocket;
+        private final ExecutorService executor;
+        private volatile boolean stopped = false;
+
+        public Listener(final ServerSocket serverSocket) {
+            this.serverSocket = serverSocket;
+            this.executor = Executors.newFixedThreadPool(2);
+        }
+
+        public void stop() {
+            stopped = true;
+
+            executor.shutdownNow();
+
+            try {
+                serverSocket.close();
+            } catch (final IOException ioe) {
+                // nothing to really do here. we could log this, but it would just become
+                // confusing in the logs, as we're shutting down and there's no real benefit
+            }
+        }
+
+        @Override
+        public void run() {
+            while (!stopped) {
+                try {
+                    final Socket socket;
+                    try {
+                        logger.debug("Listening for Bootstrap Requests");
+                        socket = serverSocket.accept();
+                    } catch (final SocketTimeoutException ste) {
+                        if (stopped) {
+                            return;
+                        }
+
+                        continue;
+                    } catch (final IOException ioe) {
+                        if (stopped) {
+                            return;
+                        }
+
+                        throw ioe;
+                    }
+
+                    logger.debug("Received connection from Bootstrap");
+                    socket.setSoTimeout(5000);
+
+                    executor.submit(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                final BootstrapRequest request = readRequest(socket.getInputStream());
+                                final BootstrapRequest.RequestType requestType = request.getRequestType();
+
+                                switch (requestType) {
+                                    case PING:
+                                        logger.debug("Received PING request from Bootstrap; responding");
+                                        echoPing(socket.getOutputStream());
+                                        logger.debug("Responded to PING request from Bootstrap");
+                                        break;
+                                    case SHUTDOWN:
+                                        logger.info("Received SHUTDOWN request from Bootstrap");
+                                        echoShutdown(socket.getOutputStream());
+                                        nifi.shutdownHook();
+                                        return;
+                                    case DUMP:
+                                        logger.info("Received DUMP request from Bootstrap");
+                                        writeDump(socket.getOutputStream());
+                                        break;
+                                }
+                            } catch (final Throwable t) {
+                                logger.error("Failed to process request from Bootstrap due to " + t.toString(), t);
+                            } finally {
+                                try {
+                                    socket.close();
+                                } catch (final IOException ioe) {
+                                    logger.warn("Failed to close socket to Bootstrap due to {}", ioe.toString());
+                                }
+                            }
+                        }
+                    });
+                } catch (final Throwable t) {
+                    logger.error("Failed to process request from Bootstrap due to " + t.toString(), t);
+                }
+            }
+        }
+    }
+
+    private static void writeDump(final OutputStream out) throws IOException {
+        final ThreadMXBean mbean = ManagementFactory.getThreadMXBean();
+        final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out));
+
+        final ThreadInfo[] infos = mbean.dumpAllThreads(true, true);
+        final long[] deadlockedThreadIds = mbean.findDeadlockedThreads();
+        final long[] monitorDeadlockThreadIds = mbean.findMonitorDeadlockedThreads();
+
+        final List<ThreadInfo> sortedInfos = new ArrayList<>(infos.length);
+        for (final ThreadInfo info : infos) {
+            sortedInfos.add(info);
+        }
+        Collections.sort(sortedInfos, new Comparator<ThreadInfo>() {
+            @Override
+            public int compare(ThreadInfo o1, ThreadInfo o2) {
+                return o1.getThreadName().toLowerCase().compareTo(o2.getThreadName().toLowerCase());
+            }
+        });
+
+        final StringBuilder sb = new StringBuilder();
+        for (final ThreadInfo info : sortedInfos) {
+            sb.append("\n");
+            sb.append("\"").append(info.getThreadName()).append("\" Id=");
+            sb.append(info.getThreadId()).append(" ");
+            sb.append(info.getThreadState().toString()).append(" ");
+
+            switch (info.getThreadState()) {
+                case BLOCKED:
+                case TIMED_WAITING:
+                case WAITING:
+                    sb.append(" on ");
+                    sb.append(info.getLockInfo());
+                    break;
+                default:
+                    break;
+            }
+
+            if (info.isSuspended()) {
+                sb.append(" (suspended)");
+            }
+            if (info.isInNative()) {
+                sb.append(" (in native code)");
+            }
+
+            if (deadlockedThreadIds != null && deadlockedThreadIds.length > 0) {
+                for (final long id : deadlockedThreadIds) {
+                    if (id == info.getThreadId()) {
+                        sb.append(" ** DEADLOCKED THREAD **");
+                    }
+                }
+            }
+
+            if (monitorDeadlockThreadIds != null && monitorDeadlockThreadIds.length > 0) {
+                for (final long id : monitorDeadlockThreadIds) {
+                    if (id == info.getThreadId()) {
+                        sb.append(" ** MONITOR-DEADLOCKED THREAD **");
+                    }
+                }
+            }
+
+            final StackTraceElement[] stackTraces = info.getStackTrace();
+            for (final StackTraceElement element : stackTraces) {
+                sb.append("\n\tat ").append(element);
+
+                final MonitorInfo[] monitors = info.getLockedMonitors();
+                for (final MonitorInfo monitor : monitors) {
+                    if (monitor.getLockedStackFrame().equals(element)) {
+                        sb.append("\n\t- waiting on ").append(monitor);
+                    }
+                }
+            }
+
+            final LockInfo[] lockInfos = info.getLockedSynchronizers();
+            if (lockInfos.length > 0) {
+                sb.append("\n\t");
+                sb.append("Number of Locked Synchronizers: ").append(lockInfos.length);
+                for (final LockInfo lockInfo : lockInfos) {
+                    sb.append("\n\t- ").append(lockInfo.toString());
+                }
+            }
+
+            sb.append("\n");
+        }
+
+        if (deadlockedThreadIds != null && deadlockedThreadIds.length > 0) {
+            sb.append("\n\nDEADLOCK DETECTED!");
+            sb.append("\nThe following thread IDs are deadlocked:");
+            for (final long id : deadlockedThreadIds) {
+                sb.append("\n").append(id);
+            }
+        }
+
+        if (monitorDeadlockThreadIds != null && monitorDeadlockThreadIds.length > 0) {
+            sb.append("\n\nMONITOR DEADLOCK DETECTED!");
+            sb.append("\nThe following thread IDs are deadlocked:");
+            for (final long id : monitorDeadlockThreadIds) {
+                sb.append("\n").append(id);
+            }
+        }
+
+        writer.write(sb.toString());
+        writer.flush();
+    }
+
+    private void echoPing(final OutputStream out) throws IOException {
+        out.write("PING\n".getBytes(StandardCharsets.UTF_8));
+        out.flush();
+    }
+
+    private void echoShutdown(final OutputStream out) throws IOException {
+        out.write("SHUTDOWN\n".getBytes(StandardCharsets.UTF_8));
+        out.flush();
+    }
+
+    @SuppressWarnings("resource")  // we don't want to close the stream, as the caller will do that
+    private BootstrapRequest readRequest(final InputStream in) throws IOException {
+        // We want to ensure that we don't try to read data from an InputStream directly
+        // by a BufferedReader because any user on the system could open a socket and send
+        // a multi-gigabyte file without any new lines in order to crash the NiFi instance
+        // (or at least cause OutOfMemoryErrors, which can wreak havoc on the running instance).
+        // So we will limit the Input Stream to only 4 KB, which should be plenty for any request.
+        final LimitingInputStream limitingIn = new LimitingInputStream(in, 4096);
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(limitingIn));
+
+        final String line = reader.readLine();
+        final String[] splits = line.split(" ");
+        if (splits.length < 1) {
+            throw new IOException("Received invalid request from Bootstrap: " + line);
+        }
+
+        final String requestType = splits[0];
+        final String[] args;
+        if (splits.length == 1) {
+            throw new IOException("Received invalid request from Bootstrap; request did not have a secret key; request type = " + requestType);
+        } else if (splits.length == 2) {
+            args = new String[0];
+        } else {
+            args = Arrays.copyOfRange(splits, 2, splits.length);
+        }
+
+        final String requestKey = splits[1];
+        if (!secretKey.equals(requestKey)) {
+            throw new IOException("Received invalid Secret Key for request type " + requestType);
+        }
+
+        try {
+            return new BootstrapRequest(requestType, args);
+        } catch (final Exception e) {
+            throw new IOException("Received invalid request from Bootstrap; request type = " + requestType);
+        }
+    }
+
+    private static class BootstrapRequest {
+
+        public static enum RequestType {
+
+            SHUTDOWN,
+            DUMP,
+            PING;
+        }
+
+        private final RequestType requestType;
+        private final String[] args;
+
+        public BootstrapRequest(final String request, final String[] args) {
+            this.requestType = RequestType.valueOf(request);
+            this.args = args;
+        }
+
+        public RequestType getRequestType() {
+            return requestType;
+        }
+
+        @SuppressWarnings("unused")
+        public String[] getArgs() {
+            return args;
+        }
+    }
+}

--- a/nifi-registry-runtime/src/main/java/org/apache/nifi/registry/NiFiRegistry.java
+++ b/nifi-registry-runtime/src/main/java/org/apache/nifi/registry/NiFiRegistry.java
@@ -18,22 +18,69 @@ package org.apache.nifi.registry;
 
 import org.apache.nifi.registry.jetty.JettyServer;
 import org.apache.nifi.registry.properties.NiFiRegistryProperties;
+import org.apache.nifi.registry.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
+import java.io.File;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Main entry point for NiFiRegistry.
  */
 public class NiFiRegistry {
 
-    private static final Logger logger = LoggerFactory.getLogger(JettyServer.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NiFiRegistry.class);
+    private static final String KEY_FILE_FLAG = "-K";
 
-    private static JettyServer server;
+    public static final String BOOTSTRAP_PORT_PROPERTY = "nifi.registry.bootstrap.listen.port";
 
-    public static void main(final String[] args) {
+    private final JettyServer server;
+    private final BootstrapListener bootstrapListener;
+    private volatile boolean shutdown = false;
+
+    public NiFiRegistry(final NiFiRegistryProperties properties)
+            throws ClassNotFoundException, IOException, NoSuchMethodException, InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+
+        // There can only be one krb5.conf for the overall Java process so set this globally during
+        // start up so that processors and our Kerberos authentication code don't have to set this
+
+        // TODO enable if we support Kerberos
+//        final File kerberosConfigFile = properties.getKerberosConfigurationFile();
+//        if (kerberosConfigFile != null) {
+//            final String kerberosConfigFilePath = kerberosConfigFile.getAbsolutePath();
+//            LOGGER.info("Setting java.security.krb5.conf to {}", new Object[]{kerberosConfigFilePath});
+//            System.setProperty("java.security.krb5.conf", kerberosConfigFilePath);
+//        }
+
+        Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(final Thread t, final Throwable e) {
+                LOGGER.error("An Unknown Error Occurred in Thread {}: {}", t, e.toString());
+                LOGGER.error("", e);
+            }
+        });
+
         // register the shutdown hook
         Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
             @Override
@@ -43,7 +90,137 @@ public class NiFiRegistry {
             }
         }));
 
-        // load the properties
+        final String bootstrapPort = System.getProperty(BOOTSTRAP_PORT_PROPERTY);
+        if (bootstrapPort != null) {
+            try {
+                final int port = Integer.parseInt(bootstrapPort);
+
+                if (port < 1 || port > 65535) {
+                    throw new RuntimeException("Failed to start NiFi Registry because system property '" + BOOTSTRAP_PORT_PROPERTY + "' is not a valid integer in the range 1 - 65535");
+                }
+
+                bootstrapListener = new BootstrapListener(this, port);
+                bootstrapListener.start();
+            } catch (final NumberFormatException nfe) {
+                throw new RuntimeException("Failed to start NiFi Registry because system property '" + BOOTSTRAP_PORT_PROPERTY + "' is not a valid integer in the range 1 - 65535");
+            }
+        } else {
+            LOGGER.info("NiFi Registry started without Bootstrap Port information provided; will not listen for requests from Bootstrap");
+            bootstrapListener = null;
+        }
+
+        // delete the web working dir - if the application does not start successfully
+        // the web app directories might be in an invalid state. when this happens
+        // jetty will not attempt to re-extract the war into the directory. by removing
+        // the working directory, we can be assured that it will attempt to extract the
+        // war every time the application starts.
+        File webWorkingDir = properties.getWebWorkingDirectory();
+        FileUtils.deleteFilesInDirectory(webWorkingDir, null, LOGGER, true, true);
+        FileUtils.deleteFile(webWorkingDir, LOGGER, 3);
+
+        detectTimingIssues();
+
+        // redirect JUL log events
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+
+        final long startTime = System.nanoTime();
+        server = new JettyServer(properties);
+
+        if (shutdown) {
+            LOGGER.info("NiFi Registry has been shutdown via NiFi Registry Bootstrap. Will not start Controller");
+        } else {
+            server.start();
+
+            if (bootstrapListener != null) {
+                bootstrapListener.sendStartedStatus(true);
+            }
+
+            final long duration = System.nanoTime() - startTime;
+            LOGGER.info("Controller initialization took " + duration + " nanoseconds "
+                    + "(" + (int) TimeUnit.SECONDS.convert(duration, TimeUnit.NANOSECONDS) + " seconds).");
+        }
+    }
+
+    protected void shutdownHook() {
+        try {
+            this.shutdown = true;
+
+            LOGGER.info("Initiating shutdown of Jetty web server...");
+            if (server != null) {
+                server.stop();
+            }
+            if (bootstrapListener != null) {
+                bootstrapListener.stop();
+            }
+            LOGGER.info("Jetty web server shutdown completed (nicely or otherwise).");
+        } catch (final Throwable t) {
+            LOGGER.warn("Problem occurred ensuring Jetty web server was properly terminated due to " + t);
+        }
+    }
+
+    /**
+     * Determine if the machine we're running on has timing issues.
+     */
+    private void detectTimingIssues() {
+        final int minRequiredOccurrences = 25;
+        final int maxOccurrencesOutOfRange = 15;
+        final AtomicLong lastTriggerMillis = new AtomicLong(System.currentTimeMillis());
+
+        final ScheduledExecutorService service = Executors.newScheduledThreadPool(1, new ThreadFactory() {
+            private final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+
+            @Override
+            public Thread newThread(final Runnable r) {
+                final Thread t = defaultFactory.newThread(r);
+                t.setDaemon(true);
+                t.setName("Detect Timing Issues");
+                return t;
+            }
+        });
+
+        final AtomicInteger occurrencesOutOfRange = new AtomicInteger(0);
+        final AtomicInteger occurrences = new AtomicInteger(0);
+        final Runnable command = new Runnable() {
+            @Override
+            public void run() {
+                final long curMillis = System.currentTimeMillis();
+                final long difference = curMillis - lastTriggerMillis.get();
+                final long millisOff = Math.abs(difference - 2000L);
+                occurrences.incrementAndGet();
+                if (millisOff > 500L) {
+                    occurrencesOutOfRange.incrementAndGet();
+                }
+                lastTriggerMillis.set(curMillis);
+            }
+        };
+
+        final ScheduledFuture<?> future = service.scheduleWithFixedDelay(command, 2000L, 2000L, TimeUnit.MILLISECONDS);
+
+        final TimerTask timerTask = new TimerTask() {
+            @Override
+            public void run() {
+                future.cancel(true);
+                service.shutdownNow();
+
+                if (occurrences.get() < minRequiredOccurrences || occurrencesOutOfRange.get() > maxOccurrencesOutOfRange) {
+                    LOGGER.warn("NiFi Registry has detected that this box is not responding within the expected timing interval, which may cause "
+                            + "Processors to be scheduled erratically. Please see the NiFi documentation for more information.");
+                }
+            }
+        };
+        final Timer timer = new Timer(true);
+        timer.schedule(timerTask, 60000L);
+    }
+
+    /**
+     * Main entry point of the application.
+     *
+     * @param args things which are ignored
+     */
+    public static void main(String[] args) {
+        LOGGER.info("Launching NiFi Registry...");
+
         final NiFiRegistryProperties properties = new NiFiRegistryProperties();
         try (final FileReader reader = new FileReader("conf/nifi-registry.properties")) {
             properties.load(reader);
@@ -51,20 +228,104 @@ public class NiFiRegistry {
             throw new RuntimeException("Unable to load properties: " + ioe, ioe);
         }
 
-        // start the server
-        server = new JettyServer(properties);
-        server.start();
+        try {
+            new NiFiRegistry(properties);
+        } catch (final Throwable t) {
+            LOGGER.error("Failure to launch NiFi Registry due to " + t, t);
+        }
     }
 
-    private static void shutdownHook() {
-        try {
-            logger.info("Initiating shutdown of Jetty web server...");
-            if (server != null) {
-                server.stop();
-            }
-            logger.info("Jetty web server shutdown completed (nicely or otherwise).");
-        } catch (final Throwable t) {
-            logger.warn("Problem occurred ensuring Jetty web server was properly terminated due to " + t);
+    private static String loadFormattedKey(String[] args) {
+        String key = null;
+        List<String> parsedArgs = parseArgs(args);
+        // Check if args contain protection key
+        if (parsedArgs.contains(KEY_FILE_FLAG)) {
+            key = getKeyFromKeyFileAndPrune(parsedArgs);
+            // Format the key (check hex validity and remove spaces)
+            key = formatHexKey(key);
         }
+
+        if (null == key) {
+            return "";
+        } else if (!isHexKeyValid(key)) {
+            throw new IllegalArgumentException("The key was not provided in valid hex format and of the correct length");
+        } else {
+            return key;
+        }
+    }
+
+    private static String getKeyFromKeyFileAndPrune(List<String> parsedArgs) {
+        String key = null;
+        LOGGER.debug("The bootstrap process provided the " + KEY_FILE_FLAG + " flag");
+        int i = parsedArgs.indexOf(KEY_FILE_FLAG);
+        if (parsedArgs.size() <= i + 1) {
+            LOGGER.error("The bootstrap process passed the {} flag without a filename", KEY_FILE_FLAG);
+            throw new IllegalArgumentException("The bootstrap process provided the " + KEY_FILE_FLAG + " flag but no key");
+        }
+        try {
+            String passwordfile_path = parsedArgs.get(i + 1);
+            // Slurp in the contents of the file:
+            byte[] encoded = Files.readAllBytes(Paths.get(passwordfile_path));
+            key = new String(encoded, StandardCharsets.UTF_8);
+            if (0 == key.length())
+                throw new IllegalArgumentException("Key in keyfile " + passwordfile_path + " yielded an empty key");
+
+            LOGGER.info("Now overwriting file in "+passwordfile_path);
+
+            // Overwrite the contents of the file (to avoid littering file system
+            // unlinked with key material):
+            File password_file = new File(passwordfile_path);
+            FileWriter overwriter = new FileWriter(password_file,false);
+
+            // Construe a random pad:
+            Random r = new Random();
+            StringBuffer sb = new StringBuffer();
+            // Note on correctness: this pad is longer, but equally sufficient.
+            while(sb.length() < encoded.length){
+                sb.append(Integer.toHexString(r.nextInt()));
+            }
+            String pad = sb.toString();
+            LOGGER.info("Overwriting key material with pad: "+pad);
+            overwriter.write(pad);
+            overwriter.close();
+
+            LOGGER.info("Removing/unlinking file: "+passwordfile_path);
+            password_file.delete();
+
+        } catch (IOException e) {
+            LOGGER.error("Caught IOException while retrieving the "+KEY_FILE_FLAG+"-passed keyfile; aborting: "+e.toString());
+            System.exit(1);
+        }
+
+        LOGGER.info("Read property protection key from key file provided by bootstrap process");
+        return key;
+    }
+
+    private static List<String> parseArgs(String[] args) {
+        List<String> parsedArgs = new ArrayList<>(Arrays.asList(args));
+        for (int i = 0; i < parsedArgs.size(); i++) {
+            if (parsedArgs.get(i).startsWith(KEY_FILE_FLAG + " ")) {
+                String[] split = parsedArgs.get(i).split(" ", 2);
+                parsedArgs.set(i, split[0]);
+                parsedArgs.add(i + 1, split[1]);
+                break;
+            }
+        }
+        return parsedArgs;
+    }
+
+    private static String formatHexKey(String input) {
+        if (input == null || input.trim().isEmpty()) {
+            return "";
+        }
+        return input.replaceAll("[^0-9a-fA-F]", "").toLowerCase();
+    }
+
+    private static boolean isHexKeyValid(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return false;
+        }
+        // Key length is in "nibbles" (i.e. one hex char = 4 bits)
+        return Arrays.asList(128, 196, 256).contains(key.length() * 4) && key.matches("^[0-9a-fA-F]*$");
     }
 }

--- a/nifi-registry-runtime/src/main/java/org/apache/nifi/registry/util/LimitingInputStream.java
+++ b/nifi-registry-runtime/src/main/java/org/apache/nifi/registry/util/LimitingInputStream.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class LimitingInputStream extends InputStream {
+
+    private final InputStream in;
+    private final long limit;
+    private long bytesRead = 0;
+
+    public LimitingInputStream(final InputStream in, final long limit) {
+        this.in = in;
+        this.limit = limit;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (bytesRead >= limit) {
+            return -1;
+        }
+
+        final int val = in.read();
+        if (val > -1) {
+            bytesRead++;
+        }
+        return val;
+    }
+
+    @Override
+    public int read(final byte[] b) throws IOException {
+        if (bytesRead >= limit) {
+            return -1;
+        }
+
+        final int maxToRead = (int) Math.min(b.length, limit - bytesRead);
+
+        final int val = in.read(b, 0, maxToRead);
+        if (val > 0) {
+            bytesRead += val;
+        }
+        return val;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (bytesRead >= limit) {
+            return -1;
+        }
+
+        final int maxToRead = (int) Math.min(len, limit - bytesRead);
+
+        final int val = in.read(b, off, maxToRead);
+        if (val > 0) {
+            bytesRead += val;
+        }
+        return val;
+    }
+
+    @Override
+    public long skip(final long n) throws IOException {
+        final long skipped = in.skip(Math.min(n, limit - bytesRead));
+        bytesRead += skipped;
+        return skipped;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return in.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        in.mark(readlimit);
+    }
+
+    @Override
+    public boolean markSupported() {
+        return in.markSupported();
+    }
+
+    @Override
+    public void reset() throws IOException {
+        in.reset();
+    }
+}

--- a/nifi-registry-utils/pom.xml
+++ b/nifi-registry-utils/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+    license agreements. See the NOTICE file distributed with this work for additional 
+    information regarding copyright ownership. The ASF licenses this file to 
+    You under the Apache License, Version 2.0 (the "License"); you may not use 
+    this file except in compliance with the License. You may obtain a copy of 
+    the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+    by applicable law or agreed to in writing, software distributed under the 
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+    OF ANY KIND, either express or implied. See the License for the specific 
+    language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.nifi.registry</groupId>
+        <artifactId>nifi-registry</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>nifi-registry-utils</artifactId>
+    <packaging>jar</packaging>
+    
+    <dependencies>
+    </dependencies>
+
+</project>

--- a/nifi-registry-utils/src/main/java/org/apache/nifi/registry/util/FileUtils.java
+++ b/nifi-registry-utils/src/main/java/org/apache/nifi/registry/util/FileUtils.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.util;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.slf4j.Logger;
+
+/**
+ * A utility class containing a few useful static methods to do typical IO
+ * operations.
+ *
+ */
+public class FileUtils {
+
+    public static final long MILLIS_BETWEEN_ATTEMPTS = 50L;
+
+    /* Superseded by renamed class bellow */
+    @Deprecated
+    public static void ensureDirectoryExistAndCanAccess(final File dir) throws IOException {
+        ensureDirectoryExistAndCanReadAndWrite(dir);
+    }
+
+    public static void ensureDirectoryExistAndCanReadAndWrite(final File dir) throws IOException {
+        if (dir.exists() && !dir.isDirectory()) {
+            throw new IOException(dir.getAbsolutePath() + " is not a directory");
+        } else if (!dir.exists()) {
+            final boolean made = dir.mkdirs();
+            if (!made) {
+                throw new IOException(dir.getAbsolutePath() + " could not be created");
+            }
+        }
+        if (!(dir.canRead() && dir.canWrite())) {
+            throw new IOException(dir.getAbsolutePath() + " directory does not have read/write privilege");
+        }
+    }
+
+    public static void ensureDirectoryExistAndCanRead(final File dir) throws IOException {
+        if (dir.exists() && !dir.isDirectory()) {
+            throw new IOException(dir.getAbsolutePath() + " is not a directory");
+        } else if (!dir.exists()) {
+            final boolean made = dir.mkdirs();
+            if (!made) {
+                throw new IOException(dir.getAbsolutePath() + " could not be created");
+            }
+        }
+        if (!dir.canRead()) {
+            throw new IOException(dir.getAbsolutePath() + " directory does not have read privilege");
+        }
+    }
+
+    /**
+     * Deletes the given file. If the given file exists but could not be deleted
+     * this will be printed as a warning to the given logger
+     *
+     * @param file to delete
+     * @param logger to notify
+     * @return true if deleted
+     */
+    public static boolean deleteFile(final File file, final Logger logger) {
+        return FileUtils.deleteFile(file, logger, 1);
+    }
+
+    /**
+     * Deletes the given file. If the given file exists but could not be deleted
+     * this will be printed as a warning to the given logger
+     *
+     * @param file to delete
+     * @param logger to notify
+     * @param attempts indicates how many times an attempt to delete should be
+     * made
+     * @return true if given file no longer exists
+     */
+    public static boolean deleteFile(final File file, final Logger logger, final int attempts) {
+        if (file == null) {
+            return false;
+        }
+        boolean isGone = false;
+        try {
+            if (file.exists()) {
+                final int effectiveAttempts = Math.max(1, attempts);
+                for (int i = 0; i < effectiveAttempts && !isGone; i++) {
+                    isGone = file.delete() || !file.exists();
+                    if (!isGone && (effectiveAttempts - i) > 1) {
+                        FileUtils.sleepQuietly(MILLIS_BETWEEN_ATTEMPTS);
+                    }
+                }
+                if (!isGone && logger != null) {
+                    logger.warn("File appears to exist but unable to delete file: " + file.getAbsolutePath());
+                }
+            }
+        } catch (final Throwable t) {
+            if (logger != null) {
+                logger.warn("Unable to delete file: '" + file.getAbsolutePath() + "' due to " + t);
+            }
+        }
+        return isGone;
+    }
+
+    /**
+     * Deletes all files (not directories..) in the given directory (non
+     * recursive) that match the given filename filter. If any file cannot be
+     * deleted then this is printed at warn to the given logger.
+     *
+     * @param directory to delete contents of
+     * @param filter if null then no filter is used
+     * @param logger to notify
+     * @throws IOException if abstract pathname does not denote a directory, or
+     * if an I/O error occurs
+     */
+    public static void deleteFilesInDirectory(final File directory, final FilenameFilter filter, final Logger logger) throws IOException {
+        FileUtils.deleteFilesInDirectory(directory, filter, logger, false);
+    }
+
+    /**
+     * Deletes all files (not directories) in the given directory (recursive)
+     * that match the given filename filter. If any file cannot be deleted then
+     * this is printed at warn to the given logger.
+     *
+     * @param directory to delete contents of
+     * @param filter if null then no filter is used
+     * @param logger to notify
+     * @param recurse true if should recurse
+     * @throws IOException if abstract pathname does not denote a directory, or
+     * if an I/O error occurs
+     */
+    public static void deleteFilesInDirectory(final File directory, final FilenameFilter filter, final Logger logger, final boolean recurse) throws IOException {
+        FileUtils.deleteFilesInDirectory(directory, filter, logger, recurse, false);
+    }
+
+    /**
+     * Deletes all files (not directories) in the given directory (recursive)
+     * that match the given filename filter. If any file cannot be deleted then
+     * this is printed at warn to the given logger.
+     *
+     * @param directory to delete contents of
+     * @param filter if null then no filter is used
+     * @param logger to notify
+     * @param recurse will look for contents of sub directories.
+     * @param deleteEmptyDirectories default is false; if true will delete
+     * directories found that are empty
+     * @throws IOException if abstract pathname does not denote a directory, or
+     * if an I/O error occurs
+     */
+    public static void deleteFilesInDirectory(final File directory, final FilenameFilter filter, final Logger logger, final boolean recurse, final boolean deleteEmptyDirectories) throws IOException {
+        // ensure the specified directory is actually a directory and that it exists
+        if (null != directory && directory.isDirectory()) {
+            final File ingestFiles[] = directory.listFiles();
+            if (ingestFiles == null) {
+                // null if abstract pathname does not denote a directory, or if an I/O error occurs
+                throw new IOException("Unable to list directory content in: " + directory.getAbsolutePath());
+            }
+            for (File ingestFile : ingestFiles) {
+                boolean process = (filter == null) ? true : filter.accept(directory, ingestFile.getName());
+                if (ingestFile.isFile() && process) {
+                    FileUtils.deleteFile(ingestFile, logger, 3);
+                }
+                if (ingestFile.isDirectory() && recurse) {
+                    FileUtils.deleteFilesInDirectory(ingestFile, filter, logger, recurse, deleteEmptyDirectories);
+                    if (deleteEmptyDirectories && ingestFile.list().length == 0) {
+                        FileUtils.deleteFile(ingestFile, logger, 3);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Deletes given files.
+     *
+     * @param files to delete
+     * @param recurse will recurse
+     * @throws IOException if issues deleting files
+     */
+    public static void deleteFiles(final Collection<File> files, final boolean recurse) throws IOException {
+        for (final File file : files) {
+            FileUtils.deleteFile(file, recurse);
+        }
+    }
+
+    public static void deleteFile(final File file, final boolean recurse) throws IOException {
+        final File[] list = file.listFiles();
+        if (file.isDirectory() && recurse && list != null) {
+            FileUtils.deleteFiles(Arrays.asList(list), recurse);
+        }
+        //now delete the file itself regardless of whether it is plain file or a directory
+        if (!FileUtils.deleteFile(file, null, 5)) {
+            throw new IOException("Unable to delete " + file.getAbsolutePath());
+        }
+    }
+
+    public static void sleepQuietly(final long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (final InterruptedException ex) {
+            /* do nothing */
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
     <description>Provides a central location for storage and management of shared resources across one or more instances of NiFi and/or MiNiFi.</description>
     <modules>
         <module>nifi-registry-properties</module>
-        <module>nifi-registry-flow-data-model</module>
+        <module>nifi-registry-utils</module>
+	<module>nifi-registry-flow-data-model</module>
         <module>nifi-registry-jetty</module>
         <module>nifi-registry-resources</module>
         <module>nifi-registry-runtime</module>
@@ -37,7 +38,8 @@
         <module>nifi-registry-service-api</module>
         <module>nifi-registry-web-api</module>
         <module>nifi-registry-web-ui</module>
-        <module>nifi-registry-assembly</module>
+        <module>nifi-registry-bootstrap</module>
+	<module>nifi-registry-assembly</module>
     </modules>
     <url>https://nifi.apache.org/registry.html</url>
     <organization>
@@ -242,7 +244,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.4</version>
+                <version>3.5</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- Enables registry to have the same setup as NiFi where a bootstrap process is started first which launches the main process
- All the standard operations such as start, stop, dump, etc, should now work from nifi-registry.sh
- Added placeholder LICENSE and NOTICE files to the assembly, need to fill in later
- Create nifi-registry-utils to hold utility code