### PR TITLE
NIFIREG-23: Fix SortParamater and OperationID in swagger.json output

### DIFF
--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/params/SortParameter.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/params/SortParameter.java
@@ -21,6 +21,12 @@ package org.apache.nifi.registry.service.params;
  */
 public class SortParameter {
 
+    public static final String API_PARAM_DESCRIPTION =
+            "Apply client-defined sorting to the resulting list of resource objects. " +
+                    "The value of this parameter should be in the format \"field:order\". " +
+                    "Valid values for 'field' can be discovered via GET :resourceURI/fields. " +
+                    "Valid values for 'order' are 'ASC' (ascending order), 'DESC' (descending order).";
+
     private final String fieldName;
 
     private final SortOrder order;

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketResource.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketResource.java
@@ -18,6 +18,7 @@ package org.apache.nifi.registry.web.api;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang3.StringUtils;
@@ -94,13 +95,17 @@ public class BucketResource {
             response = Bucket.class,
             responseContainer = "List"
     )
-    public Response getBuckets(@QueryParam("sort") final List<SortParameter> sortParameters) {
+    public Response getBuckets(
+            @ApiParam(value = SortParameter.API_PARAM_DESCRIPTION, format = "field:order", allowMultiple = true, example = "name:ASC")
+            @QueryParam("sort")
+            final List<String> sortParameters) {
 
-        final QueryParameters params = new QueryParameters.Builder()
-                .addSorts(sortParameters)
-                .build();
+        final QueryParameters.Builder paramsBuilder = new QueryParameters.Builder();
+        for (String sortParam : sortParameters) {
+            paramsBuilder.addSort(SortParameter.fromString(sortParam));
+        }
 
-        final List<Bucket> buckets = registryService.getBuckets(params);
+        final List<Bucket> buckets = registryService.getBuckets(paramsBuilder.build());
         linkService.populateBucketLinks(buckets);
 
         return Response.status(Response.Status.OK).entity(buckets).build();

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/FlowResource.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/FlowResource.java
@@ -18,6 +18,7 @@ package org.apache.nifi.registry.web.api;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang3.StringUtils;
@@ -84,13 +85,17 @@ public class FlowResource {
             response = VersionedFlow.class,
             responseContainer = "List"
     )
-    public Response getFlows(@QueryParam("sort") final List<SortParameter> sortParameters) {
+    public Response getFlows(
+            @ApiParam(value = SortParameter.API_PARAM_DESCRIPTION, format = "field:order", allowMultiple = true, example = "name:ASC")
+            @QueryParam("sort")
+            final List<String> sortParameters) {
 
-        final QueryParameters params = new QueryParameters.Builder()
-                .addSorts(sortParameters)
-                .build();
+        final QueryParameters.Builder paramsBuilder = new QueryParameters.Builder();
+        for (String sortParam : sortParameters) {
+            paramsBuilder.addSort(SortParameter.fromString(sortParam));
+        }
 
-        final List<VersionedFlow> flows = registryService.getFlows(params);
+        final List<VersionedFlow> flows = registryService.getFlows(paramsBuilder.build());
         linkService.populateFlowLinks(flows);
 
         return Response.status(Response.Status.OK).entity(flows).build();


### PR DESCRIPTION
I spent a while trying to figure out how to change the swagger.json output without changing the type of the query param from `List<SortParameter>` to `List<String>`, but in the end this was the only thing that worked for me. So now the `SortParameter.fromString()` method is called explicitly in the body of the affected methods.