### PR TITLE
NIFIREG-47 Improvements to nifi-registry-client

### DIFF
--- a/nifi-registry-client/pom.xml
+++ b/nifi-registry-client/pom.xml
@@ -21,10 +21,44 @@
     <artifactId>nifi-registry-client</artifactId>
     <packaging>jar</packaging>
 
+    <!-- Use the newest version of Jersey for the client here, since the primary client is NiFi which also uses Jersey 2.26,
+         when spring-boot 2.0.0 comes out spring-boot-jersey will use 2.26 and nifi-registry-client and backend can both use 2.2.6
+     -->
     <properties>
         <jersey.version>2.26</jersey.version>
+        <jax.rs.api.version>2.1</jax.rs.api.version>
     </properties>
-    
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>javax.ws.rs-api</artifactId>
+                <version>${jax.rs.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-client</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-json-jackson</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-common</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi.registry</groupId>
@@ -39,12 +73,18 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>${jersey.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/FlowClient.java
+++ b/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/FlowClient.java
@@ -31,13 +31,12 @@ public interface FlowClient {
     /**
      * Create the given flow in the given bucket.
      *
-     * @param bucketId a bucket id
      * @param flow the flow to create
      * @return the created flow with the identifier populated
      * @throws NiFiRegistryException if an error is encountered other than IOException
      * @throws IOException if an I/O error is encountered
      */
-    VersionedFlow create(String bucketId, VersionedFlow flow) throws NiFiRegistryException, IOException;
+    VersionedFlow create(VersionedFlow flow) throws NiFiRegistryException, IOException;
 
     /**
      * Gets the flow with the given id in the given bucket.

--- a/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/NiFiRegistryClient.java
+++ b/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/NiFiRegistryClient.java
@@ -29,9 +29,19 @@ public interface NiFiRegistryClient extends Closeable {
     BucketClient getBucketClient();
 
     /**
+     * @return the client for interacting with buckets on behalf of the given proxied entities
+     */
+    BucketClient getBucketClient(String ... proxiedEntity);
+
+    /**
      * @return the client for interacting with flows
      */
     FlowClient getFlowClient();
+
+    /**
+     * @return the client for interacting with flows on behalf of the given proxied entities
+     */
+    FlowClient getFlowClient(String ... proxiedEntity);
 
     /**
      * @return the client for interacting with flows/snapshots
@@ -39,9 +49,19 @@ public interface NiFiRegistryClient extends Closeable {
     FlowSnapshotClient getFlowSnapshotClient();
 
     /**
+     * @return the client for interacting with flows/snapshots on behalf of the given proxied entities
+     */
+    FlowSnapshotClient getFlowSnapshotClient(String ... proxiedEntity);
+
+    /**
      * @return the client for interacting with bucket items
      */
     ItemsClient getItemsClient();
+
+    /**
+     * @return the client for interacting with bucket items on behalf of the given proxied entities
+     */
+    ItemsClient getItemsClient(String ... proxiedEntity);
 
     /**
      * The builder interface that implementations should provide for obtaining the client.

--- a/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/AbstractJerseyClient.java
+++ b/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/AbstractJerseyClient.java
@@ -18,12 +18,41 @@ package org.apache.nifi.registry.client.impl;
 
 import org.apache.nifi.registry.client.NiFiRegistryException;
 
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Base class for the client operations to share exception handling.
+ *
+ * Sub-classes should always execute a request from getRequestBuilder(target) to ensure proper headers are sent.
  */
 public class AbstractJerseyClient {
+
+    private final Map<String,String> headers;
+
+    public AbstractJerseyClient(final Map<String, String> headers) {
+        this.headers = headers == null ? Collections.emptyMap() : Collections.unmodifiableMap(new HashMap<>(headers));
+    }
+
+    protected Map<String,String> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Creates a new Invocation.Builder for the given WebTarget with the headers added to the builder.
+     *
+     * @param webTarget the target for the request
+     * @return the builder for the target with the headers added
+     */
+    protected Invocation.Builder getRequestBuilder(final WebTarget webTarget) {
+        final Invocation.Builder requestBuilder = webTarget.request();
+        headers.entrySet().stream().forEach(e -> requestBuilder.header(e.getKey(), e.getValue()));
+        return requestBuilder;
+    }
 
     /**
      * Executes the given action and returns the result.

--- a/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/BucketItemDeserializer.java
+++ b/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/BucketItemDeserializer.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.client.impl;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.nifi.registry.bucket.BucketItem;
+import org.apache.nifi.registry.bucket.BucketItemType;
+import org.apache.nifi.registry.flow.VersionedFlow;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class BucketItemDeserializer extends StdDeserializer<BucketItem[]> {
+
+    public BucketItemDeserializer() {
+        super(BucketItem[].class);
+    }
+
+    @Override
+    public BucketItem[] deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+        final JsonNode arrayNode = jsonParser.getCodec().readTree(jsonParser);
+
+        final List<BucketItem> bucketItems = new ArrayList<>();
+
+        final Iterator<JsonNode> nodeIter = arrayNode.elements();
+        while (nodeIter.hasNext()) {
+            final JsonNode node = nodeIter.next();
+
+            final String type = node.get("type").asText();
+            if (StringUtils.isBlank(type)) {
+                throw new IllegalStateException("BucketItem type cannot be null or blank");
+            }
+
+            final BucketItemType bucketItemType;
+            try {
+                bucketItemType = BucketItemType.valueOf(type);
+            } catch (Exception e) {
+                throw new IllegalStateException("Unknown type for BucketItem: " + type, e);
+            }
+
+
+            switch (bucketItemType) {
+                case FLOW:
+                    final VersionedFlow versionedFlow = jsonParser.getCodec().treeToValue(node, VersionedFlow.class);
+                    bucketItems.add(versionedFlow);
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown type for BucketItem");
+            }
+        }
+
+        return bucketItems.toArray(new BucketItem[bucketItems.size()]);
+    }
+
+}

--- a/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/JerseyBucketClient.java
+++ b/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/JerseyBucketClient.java
@@ -150,7 +150,8 @@ public class JerseyBucketClient extends AbstractJerseyClient implements BucketCl
                 target = target.queryParam("sort", sortParam.toString());
             }
 
-            return getRequestBuilder(target).get(List.class);
+            final Bucket[] buckets = getRequestBuilder(target).get(Bucket[].class);
+            return buckets == null ? Collections.emptyList() : Arrays.asList(buckets);
         });
     }
 

--- a/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/JerseyItemsClient.java
+++ b/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/JerseyItemsClient.java
@@ -25,8 +25,10 @@ import org.apache.nifi.registry.params.SortParameter;
 
 import javax.ws.rs.client.WebTarget;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Jersey implementation of ItemsClient.
@@ -36,6 +38,11 @@ public class JerseyItemsClient extends AbstractJerseyClient implements ItemsClie
     private final WebTarget itemsTarget;
 
     public JerseyItemsClient(final WebTarget baseTarget) {
+        this(baseTarget, Collections.emptyMap());
+    }
+
+    public JerseyItemsClient(final WebTarget baseTarget, final Map<String,String> headers) {
+        super(headers);
         this.itemsTarget = baseTarget.path("/items");
     }
 
@@ -56,7 +63,8 @@ public class JerseyItemsClient extends AbstractJerseyClient implements ItemsClie
                 target = target.queryParam("sort", sortParam.toString());
             }
 
-            return target.request().get(List.class);
+            final BucketItem[] bucketItems = getRequestBuilder(target).get(BucketItem[].class);
+            return bucketItems == null ? Collections.emptyList() : Arrays.asList(bucketItems);
         });
     }
 
@@ -85,17 +93,16 @@ public class JerseyItemsClient extends AbstractJerseyClient implements ItemsClie
                 target = target.queryParam("sort", sortParam.toString());
             }
 
-            return target.request().get(List.class);
+            final BucketItem[] bucketItems = getRequestBuilder(target).get(BucketItem[].class);
+            return bucketItems == null ? Collections.emptyList() : Arrays.asList(bucketItems);
         });
     }
 
     @Override
     public Fields getFields() throws NiFiRegistryException, IOException {
         return executeAction("", () -> {
-            return itemsTarget
-                    .path("/fields")
-                    .request()
-                    .get(Fields.class);
+            final WebTarget target = itemsTarget.path("/fields");
+            return getRequestBuilder(target).get(Fields.class);
 
         });
     }

--- a/nifi-registry-client/src/test/java/org/apache/nifi/registry/client/impl/TestJerseyNiFiRegistryClient.java
+++ b/nifi-registry-client/src/test/java/org/apache/nifi/registry/client/impl/TestJerseyNiFiRegistryClient.java
@@ -99,6 +99,7 @@ public class TestJerseyNiFiRegistryClient {
             final List<Bucket> allBucketsSorted = bucketClient.getAll(Arrays.asList(sortParam));
             System.out.println("Retrieved sorted buckets, size = " + allBucketsSorted.size());
             Assert.assertEquals(numBuckets, allBucketsSorted.size());
+            allBucketsSorted.stream().forEach(b -> System.out.println("Retrieve bucket " + b.getIdentifier()));
 
             // update each bucket
             for (final Bucket bucket : createdBuckets) {

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/authorization/AuthorizableLookup.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/authorization/AuthorizableLookup.java
@@ -19,12 +19,20 @@ package org.apache.nifi.registry.authorization;
 import org.apache.nifi.registry.authorization.resource.Authorizable;
 
 public interface AuthorizableLookup {
+
     /**
      * Get the authorizable for retrieving resources.
      *
      * @return authorizable
      */
     Authorizable getResourcesAuthorizable();
+
+    /**
+     * Get the authorizable for /proxy.
+     *
+     * @return authorizable
+     */
+    Authorizable getProxyAuthorizable();
 
     /**
      * Get the authorizable for all tenants.

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/authorization/StandardAuthorizableLookup.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/authorization/StandardAuthorizableLookup.java
@@ -74,9 +74,26 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
         }
     };
 
+    private static final Authorizable PROXY_AUTHORIZABLE = new Authorizable() {
+        @Override
+        public Authorizable getParentAuthorizable() {
+            return null;
+        }
+
+        @Override
+        public Resource getResource() {
+            return ResourceFactory.getProxyResource();
+        }
+    };
+
     @Override
     public Authorizable getResourcesAuthorizable() {
         return RESOURCES_AUTHORIZABLE;
+    }
+
+    @Override
+    public Authorizable getProxyAuthorizable() {
+        return PROXY_AUTHORIZABLE;
     }
 
     @Override
@@ -206,6 +223,8 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
             case Tenant:
                 authorizable = getTenantsAuthorizable();
                 break;
+            case Proxy:
+                authorizable = getProxyAuthorizable();
         }
 
         if (authorizable == null) {

--- a/nifi-registry-security-api-impl/src/main/java/org/apache/nifi/registry/authorization/file/FileAccessPolicyProvider.java
+++ b/nifi-registry-security-api-impl/src/main/java/org/apache/nifi/registry/authorization/file/FileAccessPolicyProvider.java
@@ -123,6 +123,7 @@ public class FileAccessPolicyProvider implements ConfigurableAccessPolicyProvide
             new ResourceActionPair("/buckets", READ_CODE),
             new ResourceActionPair("/buckets", WRITE_CODE),
             new ResourceActionPair("/buckets", DELETE_CODE),
+            new ResourceActionPair("/proxy", WRITE_CODE)
     };
 
     static final String PROP_NODE_IDENTITY_PREFIX = "Node Identity ";

--- a/nifi-registry-web-api/pom.xml
+++ b/nifi-registry-web-api/pom.xml
@@ -211,10 +211,5 @@
             <version>0.0.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.nifi.registry</groupId>
-            <artifactId>nifi-registry-data-model</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-        </dependency>
     </dependencies>
 </project>

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/AccessPolicyResource.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/AccessPolicyResource.java
@@ -267,7 +267,7 @@ public class AccessPolicyResource extends AuthorizableApplicationResource {
 
         authorizeAccessToPolicy(RequestAction.WRITE, identifier);
 
-        AccessPolicy createdPolicy = authorizationService.createAccessPolicy(requestAccessPolicy);
+        AccessPolicy createdPolicy = authorizationService.updateAccessPolicy(requestAccessPolicy);
 
         String locationUri = generateAccessPolicyUri(createdPolicy);
         return generateCreatedResponse(URI.create(locationUri), createdPolicy).build();


### PR DESCRIPTION
- Using separate Jersey version for client only
- Added support for proxied entities
- Fixed deserializing of BucketItems
- Cleaned up methods with unnecessary parameters