### PR TITLE
NIFIREG-60 NiFi Proxy Identity Support

### DIFF
--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAuthorizer.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAuthorizer.java
@@ -122,12 +122,12 @@ public class FileAuthorizer extends AbstractPolicyBasedAuthorizer {
             accessPolicyProperties.put(FileAuthorizer.PROP_LEGACY_AUTHORIZED_USERS_FILE, configurationProperties.get(FileAuthorizer.PROP_LEGACY_AUTHORIZED_USERS_FILE));
         }
 
-        // ensure all node identities are seeded into the user provider
+        // ensure all nifi identities are seeded into the user provider
         configurationProperties.forEach((property, value) -> {
-            final Matcher matcher = FileAccessPolicyProvider.NODE_IDENTITY_PATTERN.matcher(property);
+            final Matcher matcher = FileAccessPolicyProvider.NIFI_IDENTITY_PATTERN.matcher(property);
             if (matcher.matches()) {
                 accessPolicyProperties.put(property, value);
-                userGroupProperties.put(property.replace(FileAccessPolicyProvider.PROP_NODE_IDENTITY_PREFIX, FileUserGroupProvider.PROP_INITIAL_USER_IDENTITY_PREFIX), value);
+                userGroupProperties.put(property.replace(FileAccessPolicyProvider.PROP_NIFI_IDENTITY_PREFIX, FileUserGroupProvider.PROP_INITIAL_USER_IDENTITY_PREFIX), value);
             }
         });
 

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileUserGroupProvider.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileUserGroupProvider.java
@@ -150,10 +150,10 @@ public class FileUserGroupProvider implements ConfigurableUserGroupProvider {
 
             final File tenantsFileDirectory = tenantsFile.getAbsoluteFile().getParentFile();
 
-            // extract the identity mappings from nifi.properties if any are provided
+            // extract the identity mappings from nifi-registry.properties if any are provided
             identityMappings = Collections.unmodifiableList(IdentityMappingUtil.getIdentityMappings(properties));
 
-            // extract any node identities
+            // extract any nifi identities
             initialUserIdentities = new HashSet<>();
             for (Map.Entry<String,String> entry : configurationContext.getProperties().entrySet()) {
                 Matcher matcher = INITIAL_USER_IDENTITY_PATTERN.matcher(entry.getKey());

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/ldap/tenants/LdapUserGroupProvider.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/ldap/tenants/LdapUserGroupProvider.java
@@ -331,7 +331,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
             pageSize = rawPageSize.asInteger();
         }
 
-        // extract the identity mappings from nifi.properties if any are provided
+        // extract the identity mappings from nifi-registry.properties if any are provided
         identityMappings = Collections.unmodifiableList(IdentityMappingUtil.getIdentityMappings(properties));
 
         // set the base environment is necessary

--- a/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/util/IdentityMappingUtil.java
+++ b/nifi-registry-properties/src/main/java/org/apache/nifi/registry/properties/util/IdentityMappingUtil.java
@@ -70,7 +70,7 @@ public class IdentityMappingUtil {
             }
         }
 
-        // sort the list by the key so users can control the ordering in nifi.properties
+        // sort the list by the key so users can control the ordering in nifi-registry.properties
         Collections.sort(mappings, new Comparator<IdentityMapping>() {
             @Override
             public int compare(IdentityMapping m1, IdentityMapping m2) {

--- a/nifi-registry-resources/src/main/resources/conf/authorizers.xml
+++ b/nifi-registry-resources/src/main/resources/conf/authorizers.xml
@@ -15,7 +15,7 @@
 -->
 <!--
     This file lists the userGroupProviders, accessPolicyProviders, and authorizers to use when running securely. In order
-    to use a specific authorizer it must be configured here and its identifier must be specified in the nifi.properties file.
+    to use a specific authorizer it must be configured here and its identifier must be specified in the nifi-registry.properties file.
     If the authorizer is a managedAuthorizer, it may need to be configured with an accessPolicyProvider and an userGroupProvider.
     This file allows for configuration of them, but they must be configured in order:
 
@@ -37,7 +37,7 @@
             each property must be unique, for example: "Initial User Identity A", "Initial User Identity B",
             "Initial User Identity C" or "Initial User Identity 1", "Initial User Identity 2", "Initial User Identity 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the user identities,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the user identities,
             so the values should be the unmapped identities (i.e. full DN from a certificate).
     -->
     <userGroupProvider>
@@ -101,7 +101,7 @@
             group membership will not be calculated through the groups. Will rely on group member being defined
             through 'User Group Name Attribute' if set.
 
-        NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the user identities.
+        NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the user identities.
             Group names are not mapped.
     -->
     <!-- To enable the ldap-user-group-provider remove 2 lines. This is 1 of 2.
@@ -154,8 +154,8 @@
             each property must be unique, for example: "User Group Provider A", "User Group Provider B",
             "User Group Provider C" or "User Group Provider 1", "User Group Provider 2", "User Group Provider 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties are not applied in this implementation. This behavior
-            would need to be applied by the base implementation.
+            NOTE: Any identity mapping rules specified in nifi-registry.properties are not applied in this implementation. This
+            behavior would need to be applied by the base implementation.
     -->
     <!-- To enable the composite-user-group-provider remove 2 lines. This is 1 of 2.
     <userGroupProvider>
@@ -176,8 +176,8 @@
             each property must be unique, for example: "User Group Provider A", "User Group Provider B",
             "User Group Provider C" or "User Group Provider 1", "User Group Provider 2", "User Group Provider 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties are not applied in this implementation. This behavior
-            would need to be applied by the base implementation.
+            NOTE: Any identity mapping rules specified in nifi-registry.properties are not applied in this implementation. This
+            behavior would need to be applied by the base implementation.
     -->
     <!-- To enable the composite-configurable-user-group-provider remove 2 lines. This is 1 of 2.
     <userGroupProvider>
@@ -202,15 +202,16 @@
             a DN when using certificates or LDAP. This property will only be used when there
             are no other policies defined.
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the initial admin identity,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the initial admin identity,
             so the value should be the unmapped identity. This identity must be found in the configured User Group Provider.
 
-        - Node Identity [unique key] - The identity of a NiFi cluster node. When clustered, a property for each node
-            should be defined, so that every node knows about every other node. If not clustered these properties can be ignored.
-            The name of each property must be unique, for example for a three node cluster:
-            "Node Identity A", "Node Identity B", "Node Identity C" or "Node Identity 1", "Node Identity 2", "Node Identity 3"
+        - NiFi Identity [unique key] - The identity of a NiFi node that will have access to this NiFi Registry and will be able
+            to act as a proxy on behalf of a NiFi Registry end user. A property should be created for the identity of every NiFi
+            node that needs to access this NiFi Registry. The name of each property must be unique, for example for three
+            NiFi clients:
+            "NiFi Identity A", "NiFi Identity B", "NiFi Identity C" or "NiFi Identity 1", "NiFi Identity 2", "NiFi Identity 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the node identities,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the nifi identities,
             so the values should be the unmapped identities (i.e. full DN from a certificate). This identity must be found
             in the configured User Group Provider.
     -->
@@ -221,7 +222,7 @@
         <property name="Authorizations File">./conf/authorizations.xml</property>
         <property name="Initial Admin Identity"><!-- CN=abc, OU=xyz --></property>
 
-        <!--<property name="Node Identity 1"></property>-->
+        <!--<property name="NiFi Identity 1"></property>-->
     </accessPolicyProvider>
 
     <!--

--- a/nifi-registry-web-api/src/test/resources/conf/secure-file/authorizers.xml
+++ b/nifi-registry-web-api/src/test/resources/conf/secure-file/authorizers.xml
@@ -17,7 +17,7 @@
   -->
 <!--
     This file lists the userGroupProviders, accessPolicyProviders, and authorizers to use when running securely. In order
-    to use a specific authorizer it must be configured here and its identifier must be specified in the nifi.properties file.
+    to use a specific authorizer it must be configured here and its identifier must be specified in the nifi-registry.properties file.
     If the authorizer is a managedAuthorizer, it may need to be configured with an accessPolicyProvider and an userGroupProvider.
     This file allows for configuration of them, but they must be configured in order:
 
@@ -39,7 +39,7 @@
             each property must be unique, for example: "Initial User Identity A", "Initial User Identity B",
             "Initial User Identity C" or "Initial User Identity 1", "Initial User Identity 2", "Initial User Identity 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the user identities,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the user identities,
             so the values should be the unmapped identities (i.e. full DN from a certificate).
     -->
     <userGroupProvider>
@@ -56,7 +56,7 @@
             each property must be unique, for example: "User Group Provider A", "User Group Provider B",
             "User Group Provider C" or "User Group Provider 1", "User Group Provider 2", "User Group Provider 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties are not applied in this implementation. This behavior
+            NOTE: Any identity mapping rules specified in nifi-registry.properties are not applied in this implementation. This behavior
             would need to be applied by the base implementation.
     -->
     <!-- To enable the composite-user-group-provider remove 2 lines. This is 1 of 2.
@@ -78,7 +78,7 @@
             each property must be unique, for example: "User Group Provider A", "User Group Provider B",
             "User Group Provider C" or "User Group Provider 1", "User Group Provider 2", "User Group Provider 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties are not applied in this implementation. This behavior
+            NOTE: Any identity mapping rules specified in nifi-registry.properties are not applied in this implementation. This behavior
             would need to be applied by the base implementation.
     -->
     <!-- To enable the composite-configurable-user-group-provider remove 2 lines. This is 1 of 2.
@@ -104,15 +104,14 @@
             a DN when using certificates or LDAP. This property will only be used when there
             are no other policies defined.
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the initial admin identity,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the initial admin identity,
             so the value should be the unmapped identity. This identity must be found in the configured User Group Provider.
 
-        - Node Identity [unique key] - The identity of a NiFi cluster node. When clustered, a property for each node
-            should be defined, so that every node knows about every other node. If not clustered these properties can be ignored.
-            The name of each property must be unique, for example for a three node cluster:
-            "Node Identity A", "Node Identity B", "Node Identity C" or "Node Identity 1", "Node Identity 2", "Node Identity 3"
+        - NiFi Identity [unique key] - The identity of a NiFi node that will have access to this NiFi Registry and will be able
+            to act as a proxy on behalf of a NiFi Registry end user. A property should be created for the identity of every NiFi
+            node that needs to access this NiFi Registry.
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the node identities,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the nifi identities,
             so the values should be the unmapped identities (i.e. full DN from a certificate). This identity must be found
             in the configured User Group Provider.
     -->
@@ -123,7 +122,7 @@
         <property name="Authorizations File">./target/test-classes/conf/secure-file/authorizations.xml</property>
         <property name="Initial Admin Identity">CN=user1, OU=nifi</property>
 
-        <!--<property name="Node Identity 1"></property>-->
+        <!--<property name="NiFi Identity 1"></property>-->
     </accessPolicyProvider>
 
     <!--

--- a/nifi-registry-web-api/src/test/resources/conf/secure-kerberos/authorizers.xml
+++ b/nifi-registry-web-api/src/test/resources/conf/secure-kerberos/authorizers.xml
@@ -17,7 +17,7 @@
   -->
 <!--
     This file lists the userGroupProviders, accessPolicyProviders, and authorizers to use when running securely. In order
-    to use a specific authorizer it must be configured here and its identifier must be specified in the nifi.properties file.
+    to use a specific authorizer it must be configured here and its identifier must be specified in the nifi-registry.properties file.
     If the authorizer is a managedAuthorizer, it may need to be configured with an accessPolicyProvider and an userGroupProvider.
     This file allows for configuration of them, but they must be configured in order:
 
@@ -39,7 +39,7 @@
             each property must be unique, for example: "Initial User Identity A", "Initial User Identity B",
             "Initial User Identity C" or "Initial User Identity 1", "Initial User Identity 2", "Initial User Identity 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the user identities,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the user identities,
             so the values should be the unmapped identities (i.e. full DN from a certificate).
     -->
     <userGroupProvider>
@@ -63,15 +63,14 @@
             a DN when using certificates or LDAP. This property will only be used when there
             are no other policies defined.
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the initial admin identity,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the initial admin identity,
             so the value should be the unmapped identity. This identity must be found in the configured User Group Provider.
 
-        - Node Identity [unique key] - The identity of a NiFi cluster node. When clustered, a property for each node
-            should be defined, so that every node knows about every other node. If not clustered these properties can be ignored.
-            The name of each property must be unique, for example for a three node cluster:
-            "Node Identity A", "Node Identity B", "Node Identity C" or "Node Identity 1", "Node Identity 2", "Node Identity 3"
+        - NiFi Identity [unique key] - The identity of a NiFi node that will have access to this NiFi Registry and will be able
+            to act as a proxy on behalf of a NiFi Registry end user. A property should be created for the identity of every NiFi
+            node that needs to access this NiFi Registry.
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the node identities,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the nifi identities,
             so the values should be the unmapped identities (i.e. full DN from a certificate). This identity must be found
             in the configured User Group Provider.
     -->
@@ -82,7 +81,7 @@
         <property name="Authorizations File">./target/test-classes/conf/secure-kerberos/authorizations.xml</property>
         <property name="Initial Admin Identity">kerberosUser@LOCALHOST</property>
 
-        <!--<property name="Node Identity 1"></property>-->
+        <!--<property name="NiFi Identity 1"></property>-->
     </accessPolicyProvider>
 
     <!--

--- a/nifi-registry-web-api/src/test/resources/conf/secure-kerberos/identity-providers.xml
+++ b/nifi-registry-web-api/src/test/resources/conf/secure-kerberos/identity-providers.xml
@@ -17,8 +17,8 @@
   -->
 <!--
     This file lists the login identity providers to use when running securely. In order
-    to use a specific provider it must be configured here and it's identifier
-    must be specified in the nifi.properties file.
+    to use a specific provider it must be configured here and its identifier
+    must be specified in the nifi-registry.properties file.
 -->
 <identityProviders>
 

--- a/nifi-registry-web-api/src/test/resources/conf/secure-ldap/authorizers.xml
+++ b/nifi-registry-web-api/src/test/resources/conf/secure-ldap/authorizers.xml
@@ -17,7 +17,7 @@
   -->
 <!--
     This file lists the userGroupProviders, accessPolicyProviders, and authorizers to use when running securely. In order
-    to use a specific authorizer it must be configured here and its identifier must be specified in the nifi.properties file.
+    to use a specific authorizer it must be configured here and its identifier must be specified in the nifi-registry.properties file.
     If the authorizer is a managedAuthorizer, it may need to be configured with an accessPolicyProvider and an userGroupProvider.
     This file allows for configuration of them, but they must be configured in order:
 
@@ -39,7 +39,7 @@
             each property must be unique, for example: "Initial User Identity A", "Initial User Identity B",
             "Initial User Identity C" or "Initial User Identity 1", "Initial User Identity 2", "Initial User Identity 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the user identities,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the user identities,
             so the values should be the unmapped identities (i.e. full DN from a certificate).
     -->
     <!-- To enable the file-user-group-provider remove 2 lines. This is 1 of 2.
@@ -105,7 +105,7 @@
             group membership will not be calculated through the groups. Will rely on group member being defined
             through 'User Group Name Attribute' if set.
 
-        NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the user identities.
+        NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the user identities.
             Group names are not mapped.
     -->
     <userGroupProvider>
@@ -158,7 +158,7 @@
             each property must be unique, for example: "User Group Provider A", "User Group Provider B",
             "User Group Provider C" or "User Group Provider 1", "User Group Provider 2", "User Group Provider 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties are not applied in this implementation. This behavior
+            NOTE: Any identity mapping rules specified in nifi-registry.properties are not applied in this implementation. This behavior
             would need to be applied by the base implementation.
     -->
     <!-- To enable the composite-user-group-provider remove 2 lines. This is 1 of 2.
@@ -180,7 +180,7 @@
             each property must be unique, for example: "User Group Provider A", "User Group Provider B",
             "User Group Provider C" or "User Group Provider 1", "User Group Provider 2", "User Group Provider 3"
 
-            NOTE: Any identity mapping rules specified in nifi.properties are not applied in this implementation. This behavior
+            NOTE: Any identity mapping rules specified in nifi-registry.properties are not applied in this implementation. This behavior
             would need to be applied by the base implementation.
     -->
     <!-- To enable the composite-configurable-user-group-provider remove 2 lines. This is 1 of 2.
@@ -206,15 +206,14 @@
             a DN when using certificates or LDAP. This property will only be used when there
             are no other policies defined.
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the initial admin identity,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the initial admin identity,
             so the value should be the unmapped identity. This identity must be found in the configured User Group Provider.
 
-        - Node Identity [unique key] - The identity of a NiFi cluster node. When clustered, a property for each node
-            should be defined, so that every node knows about every other node. If not clustered these properties can be ignored.
-            The name of each property must be unique, for example for a three node cluster:
-            "Node Identity A", "Node Identity B", "Node Identity C" or "Node Identity 1", "Node Identity 2", "Node Identity 3"
+        - NiFi Identity [unique key] - The identity of a NiFi node that will have access to this NiFi Registry and will be able
+            to act as a proxy on behalf of a NiFi Registry end user. A property should be created for the identity of every NiFi
+            node that needs to access this NiFi Registry.
 
-            NOTE: Any identity mapping rules specified in nifi.properties will also be applied to the node identities,
+            NOTE: Any identity mapping rules specified in nifi-registry.properties will also be applied to the nifi identities,
             so the values should be the unmapped identities (i.e. full DN from a certificate). This identity must be found
             in the configured User Group Provider.
     -->

--- a/nifi-registry-web-api/src/test/resources/conf/secure-ldap/identity-providers.xml
+++ b/nifi-registry-web-api/src/test/resources/conf/secure-ldap/identity-providers.xml
@@ -18,7 +18,7 @@
 <!--
     This file lists the login identity providers to use when running securely. In order
     to use a specific provider it must be configured here and it's identifier
-    must be specified in the nifi.properties file.
+    must be specified in the nifi-registry.properties file.
 -->
 <identityProviders>
     <!--


### PR DESCRIPTION
Adds the ability to configure NiFi Identities to act as proxies for
FileAccessPolicyProvider in authorizers.xml

Note: I plan to add new test certs and integration test cases to SecureFileIT that tests this capability in conjunction with identity mapping and the X-ProxiedEntity client header. If it would be helpful, I can include those automated tests as part of this PR.