### PR TITLE
NIFIREG-65 Return flow versions in reverse order

### DIFF
--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/RegistryService.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/RegistryService.java
@@ -46,6 +46,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -597,6 +598,13 @@ public class RegistryService {
         }
     }
 
+    /**
+     * Returns all versions of a flow, sorted newest to oldest.
+     *
+     * @param bucketIdentifier the id of the bucket to search for the flowIdentifier
+     * @param flowIdentifier the id of the flow to retrieve from the specified bucket
+     * @return all versions of the specified flow, sorted newest to oldest
+     */
     public SortedSet<VersionedFlowSnapshotMetadata> getFlowSnapshots(final String bucketIdentifier, final String flowIdentifier) {
         if (StringUtils.isBlank(bucketIdentifier)) {
             throw new IllegalArgumentException("Bucket identifier cannot be null or blank");
@@ -620,8 +628,8 @@ public class RegistryService {
                 throw new ResourceNotFoundException("VersionedFlow does not exist for identifier: " + flowIdentifier);
             }
 
-            // convert the set of FlowSnapshotEntity to set of VersionedFlowSnapshotMetadata
-            final SortedSet<VersionedFlowSnapshotMetadata> existingSnapshots = new TreeSet<>();
+            // convert the set of FlowSnapshotEntity to set of VersionedFlowSnapshotMetadata, ordered by version descending
+            final SortedSet<VersionedFlowSnapshotMetadata> existingSnapshots = new TreeSet<>(Collections.reverseOrder());
             if (existingFlow.getSnapshots() != null) {
                 existingFlow.getSnapshots().stream().forEach(s -> existingSnapshots.add(DataModelMapper.map(s)));
             }

--- a/nifi-registry-framework/src/test/java/org/apache/nifi/registry/service/TestRegistryService.java
+++ b/nifi-registry-framework/src/test/java/org/apache/nifi/registry/service/TestRegistryService.java
@@ -828,6 +828,9 @@ public class TestRegistryService {
         final SortedSet<VersionedFlowSnapshotMetadata> retrievedSnapshots = registryService.getFlowSnapshots(existingBucket.getId(), existingFlow.getId());
         assertNotNull(retrievedSnapshots);
         assertEquals(2, retrievedSnapshots.size());
+        // check that sorted set order is reversed
+        assertEquals(2, retrievedSnapshots.first().getVersion());
+        assertEquals(1, retrievedSnapshots.last().getVersion());
     }
 
     @Test

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketFlowResource.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketFlowResource.java
@@ -275,7 +275,7 @@ public class BucketFlowResource extends AuthorizableApplicationResource {
     @Consumes(MediaType.WILDCARD)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
-            value = "Gets summary information for all versions of a flow",
+            value = "Gets summary information for all versions of a flow. Versions are ordered newest->oldest.",
             response = VersionedFlowSnapshotMetadata.class,
             responseContainer = "List"
     )

--- a/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/FlowsIT.java
+++ b/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/FlowsIT.java
@@ -267,24 +267,25 @@ public class FlowsIT extends UnsecuredITBase {
 
         final String prePopulatedBucketId = "1";
         final String prePopulatedFlowId = "1";
+        // For this test case, the order of the expected list matters as we are asserting a strict equality check
         final String expected = "[" +
-                "{\"bucketIdentifier\":\"1\"," +
-                "\"flowIdentifier\":\"1\"," +
-                "\"version\":1," +
-                "\"timestamp\":1505091420000," +
-                "\"author\" : \"user1\"," +
-                "\"comments\":\"This is flow 1 snapshot 1\"," +
-                "\"link\":{\"params\":{\"rel\":\"content\"},\"href\":\"buckets/1/flows/1/versions/1\"}}," +
                 "{\"bucketIdentifier\":\"1\"," +
                 "\"flowIdentifier\":\"1\"," +
                 "\"version\":2," +
                 "\"timestamp\":1505091480000," +
                 "\"author\" : \"user2\"," +
                 "\"comments\":\"This is flow 1 snapshot 2\"," +
-                "\"link\":{\"params\":{\"rel\":\"content\"},\"href\":\"buckets/1/flows/1/versions/2\"}}]";
+                "\"link\":{\"params\":{\"rel\":\"content\"},\"href\":\"buckets/1/flows/1/versions/2\"}}," +
+                "{\"bucketIdentifier\":\"1\"," +
+                "\"flowIdentifier\":\"1\"," +
+                "\"version\":1," +
+                "\"timestamp\":1505091420000," +
+                "\"author\" : \"user1\"," +
+                "\"comments\":\"This is flow 1 snapshot 1\"," +
+                "\"link\":{\"params\":{\"rel\":\"content\"},\"href\":\"buckets/1/flows/1/versions/1\"}}" +
+                "]";
 
         // When: the /buckets/{id}/flows/{id}/versions endpoint is queried
-
         final String flowSnapshotsJson = client
                 .target(createURL("buckets/{bucketId}/flows/{flowId}/versions"))
                 .resolveTemplate("bucketId", prePopulatedBucketId)
@@ -292,9 +293,9 @@ public class FlowsIT extends UnsecuredITBase {
                 .request()
                 .get(String.class);
 
-        // Then: the pre-populated list of flow versions is returned
+        // Then: the pre-populated list of flow versions is returned, in descending order
+        JSONAssert.assertEquals(expected, flowSnapshotsJson, true);
 
-        JSONAssert.assertEquals(expected, flowSnapshotsJson, false);
     }
 
     @Test


### PR DESCRIPTION
Change the REST API endpoint that returns a list of all flow versions to sort by newest to oldest.