### PR TITLE
NIFIREG-74 Change login to use HTTP Basic Auth

### DIFF
--- a/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/BucketItemDeserializer.java
+++ b/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/impl/BucketItemDeserializer.java
@@ -61,7 +61,7 @@ public class BucketItemDeserializer extends StdDeserializer<BucketItem[]> {
 
 
             switch (bucketItemType) {
-                case FLOW:
+                case Flow:
                     final VersionedFlow versionedFlow = jsonParser.getCodec().treeToValue(node, VersionedFlow.class);
                     bucketItems.add(versionedFlow);
                     break;

--- a/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/bucket/BucketItemType.java
+++ b/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/bucket/BucketItemType.java
@@ -21,6 +21,7 @@ package org.apache.nifi.registry.bucket;
  */
 public enum BucketItemType {
 
-    FLOW;
-
+    // The case of these enum names matches what we want to return in
+    // the BucketItem.type field when serialized in an API response.
+    Flow;
 }

--- a/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/flow/VersionedFlow.java
+++ b/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/flow/VersionedFlow.java
@@ -41,7 +41,7 @@ public class VersionedFlow extends BucketItem {
     private long versionCount;
 
     public VersionedFlow() {
-        super(BucketItemType.FLOW);
+        super(BucketItemType.Flow);
     }
 
     @ApiModelProperty(value = "The number of versions of this flow.", readOnly = true)

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/NiFiRegistryApiApplication.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/NiFiRegistryApiApplication.java
@@ -18,6 +18,7 @@ package org.apache.nifi.registry;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 /**
@@ -27,8 +28,10 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
  * package across other modules. This is done because spring-boot will use the package of this
  * class to automatically scan for beans/config/entities/etc. and would otherwise require
  * configuring custom packages to scan in several different places.
+ *
+ * WebMvcAutoConfiguration is excluded because our web app is using Jersey in place of SpringMVC
  */
-@SpringBootApplication
+@SpringBootApplication(exclude = WebMvcAutoConfiguration.class)
 public class NiFiRegistryApiApplication extends SpringBootServletInitializer {
 
     public static final String NIFI_REGISTRY_PROPERTIES_ATTRIBUTE = "nifi-registry.properties";

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/NiFiRegistryResourceConfig.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/NiFiRegistryResourceConfig.java
@@ -16,25 +16,20 @@
  */
 package org.apache.nifi.registry.web;
 
+import org.apache.nifi.registry.web.api.AccessPolicyResource;
 import org.apache.nifi.registry.web.api.AccessResource;
 import org.apache.nifi.registry.web.api.BucketFlowResource;
 import org.apache.nifi.registry.web.api.BucketResource;
 import org.apache.nifi.registry.web.api.FlowResource;
 import org.apache.nifi.registry.web.api.ItemResource;
-import org.apache.nifi.registry.web.api.AccessPolicyResource;
 import org.apache.nifi.registry.web.api.TenantResource;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.filter.HttpMethodOverrideFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.filter.HiddenHttpMethodFilter;
 
-import javax.servlet.Filter;
 import javax.servlet.ServletContext;
 import javax.ws.rs.core.Context;
 
@@ -74,11 +69,4 @@ public class NiFiRegistryResourceConfig extends ResourceConfig {
         property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
     }
 
-    // Disable default SpringMVC filter beans that are not compatible with Jersey
-    @Bean
-    public FilterRegistrationBean registration(@Autowired HiddenHttpMethodFilter filter) {
-        FilterRegistrationBean registration = new FilterRegistrationBean((Filter) filter);
-        registration.setEnabled(false);
-        return registration;
-    }
 }

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketResource.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketResource.java
@@ -118,10 +118,7 @@ public class BucketResource extends AuthorizableApplicationResource {
             response = Bucket.class,
             responseContainer = "List"
     )
-    @ApiResponses({
-            @ApiResponse(code = 400, message = HttpStatusMessages.MESSAGE_400),
-            @ApiResponse(code = 401, message = HttpStatusMessages.MESSAGE_401),
-            @ApiResponse(code = 403, message = HttpStatusMessages.MESSAGE_403) })
+    @ApiResponses({ @ApiResponse(code = 401, message = HttpStatusMessages.MESSAGE_401) })
     public Response getBuckets() {
 
         // Note: We don't explicitly check for access to (READ, /buckets) because

--- a/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/FlowsIT.java
+++ b/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/FlowsIT.java
@@ -75,7 +75,7 @@ public class FlowsIT extends UnsecuredITBase {
                 "\"bucketIdentifier\":\"1\"," +
                 "\"createdTimestamp\":1505091360000," +
                 "\"modifiedTimestamp\":1505091360000," +
-                "\"type\":\"FLOW\"," +
+                "\"type\":\"Flow\"," +
                 "\"permissions\":{\"canRead\":true,\"canWrite\":true,\"canDelete\":true}," +
                 "\"link\":{\"params\":{\"rel\":\"self\"},\"href\":\"buckets/1/flows/1\"}}," +
                 "{\"identifier\":\"2\",\"name\":\"Flow 2\"," +
@@ -83,7 +83,7 @@ public class FlowsIT extends UnsecuredITBase {
                 "\"bucketIdentifier\":\"1\"," +
                 "\"createdTimestamp\":1505091360000," +
                 "\"modifiedTimestamp\":1505091360000," +
-                "\"type\":\"FLOW\"," +
+                "\"type\":\"Flow\"," +
                 "\"permissions\":{\"canRead\":true,\"canWrite\":true,\"canDelete\":true}," +
                 "\"versionCount\":0," +
                 "\"link\":{\"params\":{\"rel\":\"self\"},\"href\":\"buckets/1/flows/2\"}}" +
@@ -129,7 +129,7 @@ public class FlowsIT extends UnsecuredITBase {
         assertNotNull(createdFlow.getIdentifier());
         assertNotNull(createdFlow.getBucketName());
         assertEquals(0, createdFlow.getVersionCount());
-        assertEquals(createdFlow.getType(), BucketItemType.FLOW);
+        assertEquals(createdFlow.getType(), BucketItemType.Flow);
         assertTrue(createdFlow.getCreatedTimestamp() - testStartTime > 0L); // both server and client in same JVM, so there shouldn't be skew
         assertEquals(createdFlow.getCreatedTimestamp(), createdFlow.getModifiedTimestamp());
         assertNotNull(createdFlow.getLink());

--- a/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/SecureLdapIT.java
+++ b/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/SecureLdapIT.java
@@ -18,13 +18,13 @@ package org.apache.nifi.registry.web.api;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.registry.SecureLdapTestApiApplication;
-import org.apache.nifi.registry.bucket.Bucket;
-import org.apache.nifi.registry.extension.ExtensionManager;
 import org.apache.nifi.registry.authorization.AccessPolicy;
 import org.apache.nifi.registry.authorization.AccessPolicySummary;
 import org.apache.nifi.registry.authorization.CurrentUser;
 import org.apache.nifi.registry.authorization.Permissions;
 import org.apache.nifi.registry.authorization.Tenant;
+import org.apache.nifi.registry.bucket.Bucket;
+import org.apache.nifi.registry.extension.ExtensionManager;
 import org.apache.nifi.registry.properties.NiFiRegistryProperties;
 import org.apache.nifi.registry.security.authorization.Authorizer;
 import org.apache.nifi.registry.security.authorization.AuthorizerFactory;
@@ -104,11 +104,12 @@ public class SecureLdapIT extends IntegrationTestBase {
 
     @Before
     public void setup() {
-        final Form form = encodeCredentialsForURLFormParams("nifiadmin", "password");
+        final String basicAuthCredentials = encodeCredentialsForBasicAuth("nifiadmin", "password");
         final String token = client
-                .target(createURL(tokenLoginPath))
+                .target(createURL(tokenIdentityProviderPath))
                 .request()
-                .post(Entity.form(form), String.class);
+                .header("Authorization", "Basic " + basicAuthCredentials)
+                .post(null, String.class);
         adminAuthToken = token;
 
         beforeTestAccessPoliciesSnapshot = createAccessPoliciesSnapshot();
@@ -137,11 +138,12 @@ public class SecureLdapIT extends IntegrationTestBase {
                 "}";
 
         // When: the /access/token/login endpoint is queried
-        final Form form = encodeCredentialsForURLFormParams("nobel", "password");
+        final String basicAuthCredentials = encodeCredentialsForBasicAuth("nobel", "password");
         final Response tokenResponse = client
-                .target(createURL(tokenLoginPath))
+                .target(createURL(tokenIdentityProviderPath))
                 .request()
-                .post(Entity.form(form), Response.class);
+                .header("Authorization", "Basic " + basicAuthCredentials)
+                .post(null, Response.class);
 
         // Then: the server returns 200 OK with an access token
         assertEquals(201, tokenResponse.getStatus());
@@ -371,11 +373,12 @@ public class SecureLdapIT extends IntegrationTestBase {
         String nobelId = getTenantIdentifierByIdentity("nobel");
         String chemistsId = getTenantIdentifierByIdentity("chemists"); // a group containing user "nobel"
 
-        final Form form = encodeCredentialsForURLFormParams("nobel", "password");
+        final String basicAuthCredentials = encodeCredentialsForBasicAuth("nobel", "password");
         final String nobelAuthToken = client
-                .target(createURL(tokenLoginPath))
+                .target(createURL(tokenIdentityProviderPath))
                 .request()
-                .post(Entity.form(form), String.class);
+                .header("Authorization", "Basic " + basicAuthCredentials)
+                .post(null, String.class);
 
         // When: user nobel re-checks top-level permissions
         final CurrentUser currentUser = client


### PR DESCRIPTION
Changes the REST API /access/token/login endpoint to use HTTP Basic Auth for reading username and password.

Other minor changes included, such as:

- Swagger documentation cleanup
- FLOW -> Flow for BucketItemType serialization
