### PR TITLE
NIFIREG-112 - Add a 'diff' endpoint to the API/Client for comparing 2 versions of a flow.

### DIFF
--- a/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/diff/ComponentDifference.java
+++ b/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/diff/ComponentDifference.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.registry.diff;
+
+import io.swagger.annotations.ApiModelProperty;
+
+/**
+ * Represents a specific, individual difference that has changed between 2 versions.
+ * The change data and textual descriptions of the change are included for client consumption.
+ */
+public class ComponentDifference {
+    private String valueA;
+    private String valueB;
+    private String changeDescription;
+    private String differenceType;
+    private String differenceTypeDescription;
+
+    @ApiModelProperty("The earlier value from the difference.")
+    public String getValueA() {
+        return valueA;
+    }
+
+    public void setValueA(String valueA) {
+        this.valueA = valueA;
+    }
+
+    @ApiModelProperty("The newer value from the difference.")
+    public String getValueB() {
+        return valueB;
+    }
+
+    public void setValueB(String valueB) {
+        this.valueB = valueB;
+    }
+
+    @ApiModelProperty("The description of the change.")
+    public String getChangeDescription() {
+        return changeDescription;
+    }
+
+    public void setChangeDescription(String changeDescription) {
+        this.changeDescription = changeDescription;
+    }
+
+    @ApiModelProperty("The key to the difference.")
+    public String getDifferenceType() {
+        return differenceType;
+    }
+
+    public void setDifferenceType(String differenceType) {
+        this.differenceType = differenceType;
+    }
+
+    @ApiModelProperty("The description of the change type.")
+    public String getDifferenceTypeDescription() {
+        return differenceTypeDescription;
+    }
+
+    public void setDifferenceTypeDescription(String differenceTypeDescription) {
+        this.differenceTypeDescription = differenceTypeDescription;
+    }
+}

--- a/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/diff/ComponentDifferenceGroup.java
+++ b/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/diff/ComponentDifferenceGroup.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.registry.diff;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents a group of differences related to a specific component in a flow.
+ */
+public class ComponentDifferenceGroup {
+    private String componentId;
+    private String componentName;
+    private String componentType;
+    private String processGroupId;
+    private Set<ComponentDifference> differences = new HashSet<>();
+
+    @ApiModelProperty("The id of the component whose changes are grouped together.")
+    public String getComponentId() {
+        return componentId;
+    }
+
+    public void setComponentId(String componentId) {
+        this.componentId = componentId;
+    }
+
+    @ApiModelProperty("The name of the component whose changes are grouped together.")
+    public String getComponentName() {
+        return componentName;
+    }
+
+    public void setComponentName(String componentName) {
+        this.componentName = componentName;
+    }
+
+    @ApiModelProperty("The type of component these changes relate to.")
+    public String getComponentType() {
+        return componentType;
+    }
+
+    public void setComponentType(String componentType) {
+        this.componentType = componentType;
+    }
+
+    @ApiModelProperty("The process group id for this component.")
+    public String getProcessGroupId() {
+        return processGroupId;
+    }
+
+    public void setProcessGroupId(String processGroupId) {
+        this.processGroupId = processGroupId;
+    }
+
+    @ApiModelProperty("The list of changes related to this component between the 2 versions.")
+    public Set<ComponentDifference> getDifferences() {
+        return differences;
+    }
+
+    public void setDifferences(Set<ComponentDifference> differences) {
+        this.differences = differences;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ComponentDifferenceGroup that = (ComponentDifferenceGroup) o;
+        return Objects.equals(componentId, that.componentId)
+                && Objects.equals(componentName, that.componentName)
+                && Objects.equals(componentType, that.componentType)
+                && Objects.equals(processGroupId, that.processGroupId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(componentId, componentName, componentType, processGroupId);
+    }
+}

--- a/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/diff/VersionedFlowDifference.java
+++ b/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/diff/VersionedFlowDifference.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.nifi.registry.diff;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Set;
+
+/**
+ * Represents the result of a diff between 2 versions of the same flow.
+ * A subset of the model classes in registry.flow.diff for exposing on the API
+ * The differences are grouped by component
+ */
+public class VersionedFlowDifference {
+    private String bucketId;
+    private String flowId;
+    private int versionA;
+    private int versionB;
+    private Set<ComponentDifferenceGroup> componentDifferenceGroups;
+
+    public Set<ComponentDifferenceGroup> getComponentDifferenceGroups() {
+        return componentDifferenceGroups;
+    }
+
+    public void setComponentDifferenceGroups(Set<ComponentDifferenceGroup> componentDifferenceGroups) {
+        this.componentDifferenceGroups = componentDifferenceGroups;
+    }
+
+    @ApiModelProperty("The id of the bucket that the flow is stored in.")
+    public String getBucketId() {
+        return bucketId;
+    }
+
+    public void setBucketId(String bucketId) {
+        this.bucketId = bucketId;
+    }
+
+    @ApiModelProperty("The id of the flow that is being examined.")
+    public String getFlowId() {
+        return flowId;
+    }
+
+    public void setFlowId(String flowId) {
+        this.flowId = flowId;
+    }
+
+    @ApiModelProperty("The earlier version from the diff operation.")
+    public int getVersionA() {
+        return versionA;
+    }
+
+    public void setVersionA(int versionA) {
+        this.versionA = versionA;
+    }
+
+    @ApiModelProperty("The latter version from the diff operation.")
+    public int getVersionB() {
+        return versionB;
+    }
+
+    public void setVersionB(int versionB) {
+        this.versionB = versionB;
+    }
+}

--- a/nifi-registry-framework/pom.xml
+++ b/nifi-registry-framework/pom.xml
@@ -313,6 +313,11 @@
             <artifactId>apacheds-all</artifactId>
             <version>2.0.0-M24</version>
             <scope>test</scope>
+	</dependency>
+	<dependency>
+            <groupId>org.apache.nifi.registry</groupId>
+            <artifactId>nifi-registry-flow-diff</artifactId>
+            <version>0.1.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/DataModelMapper.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/DataModelMapper.java
@@ -22,8 +22,12 @@ import org.apache.nifi.registry.db.entity.BucketItemEntityType;
 import org.apache.nifi.registry.db.entity.FlowEntity;
 import org.apache.nifi.registry.db.entity.FlowSnapshotEntity;
 import org.apache.nifi.registry.db.entity.KeyEntity;
+import org.apache.nifi.registry.diff.ComponentDifference;
+import org.apache.nifi.registry.diff.ComponentDifferenceGroup;
+import org.apache.nifi.registry.flow.VersionedComponent;
 import org.apache.nifi.registry.flow.VersionedFlow;
 import org.apache.nifi.registry.flow.VersionedFlowSnapshotMetadata;
+import org.apache.nifi.registry.flow.diff.FlowDifference;
 import org.apache.nifi.registry.security.key.Key;
 
 import java.util.Date;
@@ -112,6 +116,35 @@ public class DataModelMapper {
         return metadata;
     }
 
+    public static ComponentDifference map(final FlowDifference flowDifference){
+        ComponentDifference diff = new ComponentDifference();
+        diff.setChangeDescription(flowDifference.getDescription());
+        diff.setDifferenceType(flowDifference.getDifferenceType().toString());
+        diff.setDifferenceTypeDescription(flowDifference.getDifferenceType().getDescription());
+        diff.setValueA(getValueDescription(flowDifference.getValueA()));
+        diff.setValueB(getValueDescription(flowDifference.getValueB()));
+        return diff;
+    }
+
+    public static ComponentDifferenceGroup map(VersionedComponent versionedComponent){
+        ComponentDifferenceGroup grouping = new ComponentDifferenceGroup();
+        grouping.setComponentId(versionedComponent.getIdentifier());
+        grouping.setComponentName(versionedComponent.getName());
+        grouping.setProcessGroupId(versionedComponent.getGroupIdentifier());
+        grouping.setComponentType(versionedComponent.getComponentType().getTypeName());
+        return grouping;
+    }
+
+    private static String getValueDescription(Object valueA){
+        if(valueA instanceof VersionedComponent){
+            return ((VersionedComponent) valueA).getIdentifier();
+        }
+        if(valueA!= null){
+            return valueA.toString();
+        }
+        return null;
+    }
+
     // --- Map keys
 
     public static Key map(final KeyEntity keyEntity) {
@@ -129,5 +162,7 @@ public class DataModelMapper {
         keyEntity.setKeyValue(key.getKey());
         return keyEntity;
     }
+
+    // map
 
 }

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketFlowResource.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/BucketFlowResource.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.registry.bucket.BucketItem;
 import org.apache.nifi.registry.exception.ResourceNotFoundException;
 import org.apache.nifi.registry.flow.VersionedFlow;
+import org.apache.nifi.registry.diff.VersionedFlowDifference;
 import org.apache.nifi.registry.flow.VersionedFlowSnapshot;
 import org.apache.nifi.registry.flow.VersionedFlowSnapshotMetadata;
 import org.apache.nifi.registry.security.authorization.Authorizer;
@@ -400,6 +401,32 @@ public class BucketFlowResource extends AuthorizableApplicationResource {
         populateLinksAndPermissions(snapshot);
 
         return Response.status(Response.Status.OK).entity(snapshot).build();
+    }
+
+    @GET
+    @Path("{flowId}/diff/{versionA: \\d+}/{versionB: \\d+}")
+    @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+            value = "Returns a list of differences between 2 versions of a flow",
+            response = VersionedFlowDifference.class
+    )
+    @ApiResponses({
+            @ApiResponse(code = 400, message = HttpStatusMessages.MESSAGE_400),
+            @ApiResponse(code = 401, message = HttpStatusMessages.MESSAGE_401),
+            @ApiResponse(code = 403, message = HttpStatusMessages.MESSAGE_403),
+            @ApiResponse(code = 404, message = HttpStatusMessages.MESSAGE_404),
+            @ApiResponse(code = 409, message = HttpStatusMessages.MESSAGE_409)})
+    public Response getFlowDiff(@PathParam("bucketId")
+                                @ApiParam("The bucket identifier") final String bucketId,
+                                @PathParam("flowId")
+                                @ApiParam("The flow identifier") final String flowId,
+                                @PathParam("versionA")
+                                @ApiParam("The first version number") final Integer versionNumberA,
+                                @PathParam("versionB")
+                                @ApiParam("The second version number") final Integer versionNumberB) {
+        VersionedFlowDifference result = registryService.getFlowDiff(bucketId, flowId, versionNumberA, versionNumberB);
+        return Response.status(Response.Status.OK).entity(result).build();
     }
 
     private void populateLinksAndPermissions(VersionedFlowSnapshot snapshot) {


### PR DESCRIPTION
This PR is for an API endpoint to get a diff between 2 versions of a flow. 
[NIFIREG-77](https://issues.apache.org/jira/projects/NIFIREG/issues/NIFIREG-77) is the parent task and [NIFIREG-112](https://issues.apache.org/jira/projects/NIFIREG/issues/NIFIREG-112) is the sub task.
There is some discussion on the parent task around direction etc. 
Let me know if there's anything I should change. Thanks.