### PR TITLE
NIFIREG-120 Basic Docker Image Support

### DIFF
--- a/nifi-registry-docker/dockerhub/.dockerignore
+++ b/nifi-registry-docker/dockerhub/.dockerignore
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Place files you want to exclude from the docker build here similar to .gitignore https://docs.docker.com/engine/reference/builder/#dockerignore-file
+DockerBuild.sh
+DockerRun.sh
+DockerImage.txt

--- a/nifi-registry-docker/dockerhub/DockerBuild.sh
+++ b/nifi-registry-docker/dockerhub/DockerBuild.sh
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+DOCKER_UID=1000
+if [ -n "$1" ]; then
+  DOCKER_UID="$1"
+fi
+
+DOCKER_GID=1000
+if [ -n "$2" ]; then
+  DOCKER_GID="$2"
+fi
+
+MIRROR=https://archive.apache.org/dist
+if [ -n "$3" ]; then
+  MIRROR="$3"
+fi
+
+DOCKER_IMAGE="$(egrep -v '(^#|^\s*$|^\s*\t*#)' DockerImage.txt)"
+NIFI_REGISTRY_IMAGE_VERSION="$(echo $DOCKER_IMAGE | cut -d : -f 2)"
+echo "Building NiFi-Registry Image: '$DOCKER_IMAGE' Version: NIFI_REGISTRY_IMAGE_VERSION Mirror: $MIRROR"
+docker build --build-arg UID="$DOCKER_UID" --build-arg GID="$DOCKER_GID" --build-arg NIFI_REGISTRY_VERSION="$NIFI_REGISTRY_IMAGE_VERSION" --build-arg MIRROR="$MIRROR" -t $DOCKER_IMAGE .

--- a/nifi-registry-docker/dockerhub/DockerImage.txt
+++ b/nifi-registry-docker/dockerhub/DockerImage.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apache/nifi-registry:0.2.0

--- a/nifi-registry-docker/dockerhub/DockerRun.sh
+++ b/nifi-registry-docker/dockerhub/DockerRun.sh
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+DOCKER_IMAGE="$(egrep -v '(^#|^\s*$|^\s*\t*#)' DockerImage.txt)"
+echo "Running Docker Image: $DOCKER_IMAGE"
+docker run -it -d -p 18080:18080 $DOCKER_IMAGE

--- a/nifi-registry-docker/dockerhub/Dockerfile
+++ b/nifi-registry-docker/dockerhub/Dockerfile
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM openjdk:8-jdk-slim
+LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
+LABEL site="https://nifi.apache.org"
+
+ARG UID=1000
+ARG GID=1000
+ARG NIFI_REGISTRY_VERSION=0.1.0
+ARG MIRROR=https://archive.apache.org/dist
+
+ENV NIFI_REGISTRY_BASE_DIR /opt/nifi-registry
+ENV NIFI_REGISTRY_HOME=${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${NIFI_REGISTRY_VERSION} \
+    NIFI_REGISTRY_BINARY_URL=nifi/nifi-registry/nifi-registry-${NIFI_REGISTRY_VERSION}/nifi-registry-${NIFI_REGISTRY_VERSION}-bin.tar.gz
+
+ADD sh/ ${NIFI_REGISTRY_BASE_DIR}/scripts/
+
+# Setup NiFi-Registry user
+RUN groupadd -g ${GID} nifi || groupmod -n nifi `getent group ${GID} | cut -d: -f1` \
+    && useradd --shell /bin/bash -u ${UID} -g ${GID} -m nifi \
+    && chown -R nifi:nifi ${NIFI_REGISTRY_BASE_DIR} \
+    && apt-get update -y \
+    && apt-get install -y curl jq xmlstarlet
+
+USER nifi
+
+# Download, validate, and expand Apache NiFi-Registry binary.
+RUN curl -fSL ${MIRROR}/${NIFI_REGISTRY_BINARY_URL} -o ${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${NIFI_REGISTRY_VERSION}-bin.tar.gz \
+    && echo "$(curl ${MIRROR}/${NIFI_REGISTRY_BINARY_URL}.sha256) *${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${NIFI_REGISTRY_VERSION}-bin.tar.gz" | sha256sum -c - \
+    && tar -xvzf ${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${NIFI_REGISTRY_VERSION}-bin.tar.gz -C ${NIFI_REGISTRY_BASE_DIR} \
+    && rm ${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${NIFI_REGISTRY_VERSION}-bin.tar.gz \
+    && chown -R nifi:nifi ${NIFI_REGISTRY_HOME}
+
+# Web HTTP(s) ports
+EXPOSE 18080 18443
+
+WORKDIR ${NIFI_REGISTRY_HOME}
+
+# Apply configuration and start NiFi Registry
+CMD ${NIFI_REGISTRY_BASE_DIR}/scripts/start.sh

--- a/nifi-registry-docker/dockerhub/README.md
+++ b/nifi-registry-docker/dockerhub/README.md
@@ -1,0 +1,127 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Docker Image Quickstart
+
+## Capabilities
+This image currently supports running in standalone mode either unsecured or with user authentication provided through:
+   * [Two-Way SSL with Client Certificates](https://nifi.apache.org/docs/nifi-registry-docs/html/administration-guide.html#security-configuration)
+   * [Lightweight Directory Access Protocol (LDAP)](https://nifi.apache.org/docs/nifi-registry-docs/html/administration-guide.html#ldap_identity_provider)
+   
+## Building
+The Docker image can be built using the following command:
+
+    . ~/Projects/nifi-dev/nifi-registry/nifi-registry-docker/dockerhub/DockerBuild.sh
+
+This will attempt to build and tag an image matching the string in DockerImage.txt
+
+    dockerhub dchaffey$ cat DockerImage.txt
+    > apache/nifi-registry:0.1.0
+    docker images
+    > REPOSITORY               TAG                 IMAGE ID            CREATED             SIZE
+    > apache/nifi-registry     0.1.0               751428cbf631        15 minutes ago      342MB
+    
+**Note**: The default version of NiFi-Registry specified by the Dockerfile is typically that of one that is unreleased if working from source.
+To build an image for a prior released version, one can override the `NIFI_REGISTRY_VERSION` build-arg with the following command:
+    
+    docker build --build-arg=NIFI_REGISRTY_VERSION={Desired NiFi-Registry Version} -t apache/nifi-registry:latest .
+
+There is, however, no guarantee that older versions will work as properties have changed and evolved with subsequent releases.
+The configuration scripts are suitable for at least 0.1.0+.
+
+## Running a container
+
+### Standalone Instance, Unsecured
+The minimum to run a NiFi Registry instance is as follows:
+
+    . ~/Projects/nifi-dev/nifi-registry/nifi-registry-docker/dockerhub/DockerRun.sh
+      
+This will provide a running instance, exposing the instance UI to the host system on at port 18080,
+viewable at `http://localhost:18080/nifi-registry`.
+For a list of the environment variables recognised in this build, look into the .sh/secure.sh and .sh/start.sh scripts
+        
+### Standalone Instance, Two-Way SSL
+In this configuration, the user will need to provide certificates and the associated configuration information.
+Of particular note, is the `AUTH` environment variable which is set to `tls`.  Additionally, the user must provide an
+the DN as provided by an accessing client certificate in the `INITIAL_ADMIN_IDENTITY` environment variable.
+This value will be used to seed the instance with an initial user with administrative privileges.
+Finally, this command makes use of a volume to provide certificates on the host system to the container instance.
+
+    docker run --name nifi-registry \
+      -v /User/bob/certs/localhost:/opt/certs \
+      -p 8443:8443 \
+      -e AUTH=tls \
+      -e KEYSTORE_PATH=/opt/certs/keystore.jks \
+      -e KEYSTORE_TYPE=JKS \
+      -e KEYSTORE_PASSWORD=QKZv1hSWAFQYZ+WU1jjF5ank+l4igeOfQRp+OSbkkrs \
+      -e TRUSTSTORE_PATH=/opt/certs/truststore.jks \
+      -e TRUSTSTORE_PASSWORD=rHkWR1gDNW3R9hgbeRsT3OM3Ue0zwGtQqcFKJD2EXWE \
+      -e TRUSTSTORE_TYPE=JKS \
+      -e INITIAL_ADMIN_IDENTITY='CN=Random User, O=Apache, OU=NiFiRegistry, C=US' \
+      -d \
+      apache/nifi-registry:latest
+
+### Standalone Instance, LDAP
+In this configuration, the user will need to provide certificates and the associated configuration information.  Optionally,
+if the LDAP provider of interest is operating in LDAPS or START_TLS modes, certificates will additionally be needed.
+Of particular note, is the `AUTH` environment variable which is set to `ldap`.  Additionally, the user must provide a
+DN as provided by the configured LDAP server in the `INITIAL_ADMIN_IDENTITY` environment variable. This value will be 
+used to seed the instance with an initial user with administrative privileges.  Finally, this command makes use of a 
+volume to provide certificates on the host system to the container instance.
+
+#### For a minimal, connection to an LDAP server using SIMPLE authentication:
+
+    docker run --name nifi-registry \
+      -v /User/bob/certs/localhost:/opt/certs \
+      -p 8443:8443 \
+      -e AUTH=tls \
+      -e KEYSTORE_PATH=/opt/certs/keystore.jks \
+      -e KEYSTORE_TYPE=JKS \
+      -e KEYSTORE_PASSWORD=QKZv1hSWAFQYZ+WU1jjF5ank+l4igeOfQRp+OSbkkrs \
+      -e TRUSTSTORE_PATH=/opt/certs/truststore.jks \
+      -e TRUSTSTORE_PASSWORD=rHkWR1gDNW3R9hgbeRsT3OM3Ue0zwGtQqcFKJD2EXWE \
+      -e TRUSTSTORE_TYPE=JKS \
+      -e INITIAL_ADMIN_IDENTITY='cn=admin,dc=example,dc=org' \
+      -e LDAP_AUTHENTICATION_STRATEGY='SIMPLE' \
+      -e LDAP_MANAGER_DN='cn=admin,dc=example,dc=org' \
+      -e LDAP_MANAGER_PASSWORD='password' \
+      -e LDAP_USER_SEARCH_BASE='dc=example,dc=org' \
+      -e LDAP_USER_SEARCH_FILTER='cn={0}' \
+      -e LDAP_IDENTITY_STRATEGY='USE_DN' \
+      -e LDAP_URL='ldap://ldap:389' \
+      -d \
+      apache/nifi-registry:latest
+
+#### The following, optional environment variables may be added to the above command when connecting to a secure  LDAP server configured with START_TLS or LDAPS
+
+    -e LDAP_TLS_KEYSTORE: ''
+    -e LDAP_TLS_KEYSTORE_PASSWORD: ''
+    -e LDAP_TLS_KEYSTORE_TYPE: ''
+    -e LDAP_TLS_TRUSTSTORE: ''
+    -e LDAP_TLS_TRUSTSTORE_PASSWORD: ''
+    -e LDAP_TLS_TRUSTSTORE_TYPE: ''
+
+## Configuration Information
+The following ports are specified by default in Docker for NiFi-Registry operation within the container and 
+can be published to the host.
+
+| Function                 | Property                      | Port  |
+|--------------------------|-------------------------------|-------|
+| HTTP Port                | nifi.web.http.port            | 18080  |
+| HTTPS Port               | nifi.web.https.port           | 18443  |
+
+The following base image is used for NiFi-Registry, which differs from the NiFi Docker image:
+    
+    openjdk:8-jdk-slim

--- a/nifi-registry-docker/dockerhub/sh/common.sh
+++ b/nifi-registry-docker/dockerhub/sh/common.sh
@@ -1,0 +1,28 @@
+#!/bin/sh -e
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# 1 - value to search for
+# 2 - value to replace
+# 3 - file to perform replacement inline
+prop_replace () {
+  target_file=${3:-${nifi_registry_props_file}}
+  echo 'replacing target file ' ${target_file}
+  sed -i -e "s|^$1=.*$|$1=$2|"  ${target_file}
+}
+
+# NIFI_REGISTRY_HOME is defined by an ENV command in the backing Dockerfile
+export nifi_registry_props_file=${NIFI_REGISTRY_HOME}/conf/nifi-registry.properties
+export hostname=$(hostname)

--- a/nifi-registry-docker/dockerhub/sh/secure.sh
+++ b/nifi-registry-docker/dockerhub/sh/secure.sh
@@ -1,0 +1,56 @@
+#!/bin/sh -e
+
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+scripts_dir='/opt/nifi-registry/scripts'
+
+[ -f "${scripts_dir}/common.sh" ] && . "${scripts_dir}/common.sh"
+
+# Perform idempotent changes of configuration to support secure environments
+echo 'Configuring environment with SSL settings'
+
+: ${KEYSTORE_PATH:?"Must specify an absolute path to the keystore being used."}
+if [ ! -f "${KEYSTORE_PATH}" ]; then
+    echo "Keystore file specified (${KEYSTORE_PATH}) does not exist."
+    exit 1
+fi
+: ${KEYSTORE_TYPE:?"Must specify the type of keystore (JKS, PKCS12, PEM) of the keystore being used."}
+: ${KEYSTORE_PASSWORD:?"Must specify the password of the keystore being used."}
+
+: ${TRUSTSTORE_PATH:?"Must specify an absolute path to the truststore being used."}
+if [ ! -f "${TRUSTSTORE_PATH}" ]; then
+    echo "Keystore file specified (${TRUSTSTORE_PATH}) does not exist."
+    exit 1
+fi
+: ${TRUSTSTORE_TYPE:?"Must specify the type of truststore (JKS, PKCS12, PEM) of the truststore being used."}
+: ${TRUSTSTORE_PASSWORD:?"Must specify the password of the truststore being used."}
+
+prop_replace 'nifi.registry.security.keystore'           "${KEYSTORE_PATH}"
+prop_replace 'nifi.registry.security.keystoreType'       "${KEYSTORE_TYPE}"
+prop_replace 'nifi.registry.security.keystorePasswd'     "${KEYSTORE_PASSWORD}"
+prop_replace 'nifi.registry.security.truststore'         "${TRUSTSTORE_PATH}"
+prop_replace 'nifi.registry.security.truststoreType'     "${TRUSTSTORE_TYPE}"
+prop_replace 'nifi.registry.security.truststorePasswd'   "${TRUSTSTORE_PASSWORD}"
+
+# Disable HTTP and enable HTTPS
+prop_replace 'nifi.registry.web.http.port'   ''
+prop_replace 'nifi.registry.web.http.host'   ''
+prop_replace 'nifi.registry.web.https.port'  "${NIFI_REGISTRY_WEB_HTTPS_PORT:-18443}"
+prop_replace 'nifi.registry.web.https.host'  "${NIFI_REGISTRY_WEB_HTTPS_HOST:-$HOSTNAME}"
+
+# Establish initial user and an associated admin identity
+sed -i -e 's|<property name="Initial User Identity 1">.*</property>|<property name="Initial User Identity 1">'"${INITIAL_ADMIN_IDENTITY}"'</property>|'  ${NIFI_REGISTRY_HOME}/conf/authorizers.xml
+sed -i -e 's|<property name="Initial Admin Identity">.*</property>|<property name="Initial Admin Identity">'"${INITIAL_ADMIN_IDENTITY}"'</property>|'  ${NIFI_REGISTRY_HOME}/conf/authorizers.xml

--- a/nifi-registry-docker/dockerhub/sh/start.sh
+++ b/nifi-registry-docker/dockerhub/sh/start.sh
@@ -1,0 +1,51 @@
+#!/bin/sh -e
+
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+scripts_dir='/opt/nifi-registry/scripts'
+
+[ -f "${scripts_dir}/common.sh" ] && . "${scripts_dir}/common.sh"
+
+# Establish baseline properties
+prop_replace 'nifi.registry.web.http.port'      "${NIFI_REGISTRY_WEB_HTTP_PORT:-18080}"
+prop_replace 'nifi.registry.web.http.host'      "${NIFI_REGISTRY_WEB_HTTP_HOST:-$HOSTNAME}"
+
+# Check if we are secured or unsecured
+case ${AUTH} in
+    tls)
+        echo 'Enabling Two-Way SSL user authentication'
+        . "${scripts_dir}/secure.sh"
+        ;;
+    ldap)
+        echo 'Enabling LDAP user authentication'
+        # Reference ldap-provider in properties
+        prop_replace 'nifi.registry.security.identity.provider' 'ldap-identity-provider'
+        prop_replace 'nifi.registry.security.needClientAuth' 'false'
+
+        . "${scripts_dir}/secure.sh"
+        . "${scripts_dir}/update_login_providers.sh"
+        ;;
+esac
+
+# Continuously provide logs so that 'docker logs' can produce them
+tail -F "${NIFI_REGISTRY_HOME}/logs/nifi-registry-app.log" &
+"${NIFI_REGISTRY_HOME}/bin/nifi-registry.sh" run &
+nifi_registry_pid="$!"
+
+trap "echo Received trapped signal, beginning shutdown...;" KILL TERM HUP INT EXIT;
+
+echo NiFi-Registry running with PID ${nifi_registry_pid}.
+wait ${nifi_registry_pid}

--- a/nifi-registry-docker/dockerhub/sh/update_login_providers.sh
+++ b/nifi-registry-docker/dockerhub/sh/update_login_providers.sh
@@ -1,0 +1,48 @@
+#!/bin/sh -e
+
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+login_providers_file=${NIFI_REGISTRY_HOME}/conf/identity-providers.xml
+property_xpath='//identityProviders/provider/property'
+
+# Update a given property in the login-identity-providers file if a value is specified
+edit_property() {
+  property_name=$1
+  property_value=$2
+
+  if [ -n "${property_value}" ]; then
+    xmlstarlet ed --inplace -u "${property_xpath}[@name='${property_name}']" -v "${property_value}" "${login_providers_file}"
+  fi
+}
+
+# Remove comments to enable the ldap-provider
+sed -i '/To enable the ldap-identity-provider remove/d' "${login_providers_file}"
+
+edit_property 'Authentication Strategy'     "${LDAP_AUTHENTICATION_STRATEGY}"
+edit_property 'Manager DN'                  "${LDAP_MANAGER_DN}"
+edit_property 'Manager Password'            "${LDAP_MANAGER_PASSWORD}"
+edit_property 'TLS - Keystore'              "${LDAP_TLS_KEYSTORE}"
+edit_property 'TLS - Keystore Password'     "${LDAP_TLS_KEYSTORE_PASSWORD}"
+edit_property 'TLS - Keystore Type'         "${LDAP_TLS_KEYSTORE_TYPE}"
+edit_property 'TLS - Truststore'            "${LDAP_TLS_TRUSTSTORE}"
+edit_property 'TLS - Truststore Password'   "${LDAP_TLS_TRUSTSTORE_PASSWORD}"
+edit_property 'TLS - Truststore Type'       "${LDAP_TLS_TRUSTSTORE_TYPE}"
+edit_property 'TLS - Protocol'              "${LDAP_TLS_PROTOCOL}"
+edit_property 'Url'                         "${LDAP_URL}"
+edit_property 'User Search Base'            "${LDAP_USER_SEARCH_BASE}"
+edit_property 'User Search Filter'          "${LDAP_USER_SEARCH_FILTER}"
+<<<<<<< f271b0a5e09d90ac935c655f3a9d2faa0957a646
+edit_property 'Identity Strategy'           "${LDAP_IDENTITY_STRATEGY}"

--- a/nifi-registry-docker/pom.xml
+++ b/nifi-registry-docker/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>nifi-registry</artifactId>
+        <groupId>org.apache.nifi.registry</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>nifi-registry-docker</artifactId>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,8 @@
 	    <module>nifi-registry-bootstrap</module>
         <module>nifi-registry-docs</module>
         <module>nifi-registry-assembly</module>
-	<module>nifi-registry-client</module>
+	    <module>nifi-registry-client</module>
+        <module>nifi-registry-docker</module>
     </modules>
     <url>https://nifi.apache.org/registry.html</url>
     <organization>


### PR DESCRIPTION
NIFIREG-120 Ported a simplified version of the Dockerhub image from the main NiFI project.