### PR TITLE
NIFIREG-131 Surface auth failure details

### DIFF
--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/x509/X509IdentityAuthenticationProvider.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/x509/X509IdentityAuthenticationProvider.java
@@ -100,7 +100,7 @@ public class X509IdentityAuthenticationProvider extends IdentityAuthenticationPr
                 try {
                     PROXY_AUTHORIZABLE.authorize(authorizer, RequestAction.WRITE, proxy);
                 } catch (final AccessDeniedException e) {
-                    throw new UntrustedProxyException(String.format("Untrusted proxy %s", identity));
+                    throw new UntrustedProxyException(String.format("Untrusted proxy [%s].", identity));
                 }
             }
         }


### PR DESCRIPTION
Adds logging of root cause for exceptions passed to
AuthenticationEntryPoint.

AuthenticationEntryPoint writes exception message to response body.