### PR TITLE
NIFIREG-172 Adds Swagger UI

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,13 @@
 Apache NiFi Registry
-Copyright 2014-2017 The Apache Software Foundation
+Copyright 2014-2018 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 This includes derived works from the Apache NiFi (ASLv2 licensed) project (https://git-wip-us.apache.org/repos/asf?p=nifi.git):
-  Copyright 2015-2017 The Apache Software Foundation
+  Copyright 2015-2018 The Apache Software Foundation
   This includes sources for bootstrapping, runtime, component API, security/authorization API
+
+This includes derived works from the Apache NiFi MiNiFi (ASLv2 licensed) project (https://git-wip-us.apache.org/repos/asf/nifi-minifi.git):
+  Copyright 2015-2018 The Apache Software Foundation
+  This includes build configuration for the Swagger UI.

--- a/README.md
+++ b/README.md
@@ -51,14 +51,20 @@ Registry—a subproject of Apache NiFi—is a complementary application that pro
 
         cd nifi-registry-assembly/target/nifi-registry-<VERSION>-bin/nifi-registry-<VERSION>/
         ./bin/nifi-registry.sh start
-
-4) Launch the application
- 
-    With the default settings, the application will be available at [http://localhost:18080/nifi-registry](http://localhost:18080/nifi-registry) 
    
-5) Logging
+   Note that the application web server can take a while to load before it is accessible.   
 
-    Logs will be available in logs/nifi-registry.app.log  
+4) Accessing the application web UI
+ 
+    With the default settings, the application UI will be available at [http://localhost:18080/nifi-registry](http://localhost:18080/nifi-registry) 
+   
+5) Accessing the application REST API
+
+    If you wish to test against the application REST API, you can access the REST API directly. With the default settings, the base URL of the REST API will be at `http://localhost:18080/nifi-registry-api`. A UI for testing the REST API will be available at [http://localhost:18080/nifi-registry-api/swagger/ui.html](http://localhost:18080/nifi-registry-api/swagger/ui.html) 
+
+6) Accessing the application logs
+
+    Logs will be available in `logs/nifi-registry-app.log`
 
 ## License
 

--- a/nifi-registry-assembly/NOTICE
+++ b/nifi-registry-assembly/NOTICE
@@ -1,5 +1,5 @@
 Apache NiFi Registry
-Copyright 2014-2017 The Apache Software Foundation
+Copyright 2014-2018 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/nifi-registry-assembly/NOTICE
+++ b/nifi-registry-assembly/NOTICE
@@ -163,29 +163,29 @@ The following binary components are provided under the Apache Software License v
       Apache log4j
       Copyright 2010 The Apache Software Foundation
 
-   (ASLv2) Spring Framework
-     The following NOTICE information applies:
-       Spring Framework 5.0.2.RELEASE
-       Copyright (c) 2002-2017 Pivotal, Inc.
+  (ASLv2) Spring Framework
+    The following NOTICE information applies:
+      Spring Framework 5.0.2.RELEASE
+      Copyright (c) 2002-2017 Pivotal, Inc.
 
-   (ASLv2) Spring Security
-     The following NOTICE information applies:
-       Spring Framework 5.0.5.RELEASE
-       Copyright (c) 2002-2017 Pivotal, Inc.
+  (ASLv2) Spring Security
+    The following NOTICE information applies:
+      Spring Framework 5.0.5.RELEASE
+      Copyright (c) 2002-2017 Pivotal, Inc.
 
-       This product includes software developed by Spring Security
-       Project (http://www.springframework.org/security).
+      This product includes software developed by Spring Security
+      Project (http://www.springframework.org/security).
 
-   (ASLv2) Spring LDAP
-      The following NOTICE information applies:
-        Spring LDAP 2.3.2.RELEASE
-        Copyright (c) 2002-2017 Pivotal, Inc.
+  (ASLv2) Spring LDAP
+    The following NOTICE information applies:
+      Spring LDAP 2.3.2.RELEASE
+      Copyright (c) 2002-2017 Pivotal, Inc.
 
-        This product includes software developed by the Spring LDAP
-        Project (http://www.springframework.org/ldap).
+      This product includes software developed by the Spring LDAP
+      Project (http://www.springframework.org/ldap).
 
-   (ASLv2) Apache Tomcat Embed EL
-      The following NOTICE information applies:
+  (ASLv2) Apache Tomcat Embed EL
+    The following NOTICE information applies:
         Apache Tomcat
         Copyright 1999-2017 The Apache Software Foundation
 
@@ -242,9 +242,14 @@ The following binary components are provided under the Apache Software License v
         may be obtained from:
         http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/index.html
 
-   (ASLv2) SnakeYAML
-      The following NOTICE information applies:
-        Copyright (c) 2008, http://www.snakeyaml.org
+  (ASLv2) SnakeYAML
+    The following NOTICE information applies:
+      Copyright (c) 2008, http://www.snakeyaml.org
+
+  (ASLv2) Swagger UI
+    The following NOTICE information applies:
+      Copyright 2017 SmartBear Software
+
 
 ************************
 Common Development and Distribution License 1.1

--- a/nifi-registry-assembly/README.md
+++ b/nifi-registry-assembly/README.md
@@ -29,9 +29,9 @@ Registry—a subproject of Apache NiFi—is a complementary application that pro
 
 ## Getting Started
 
-To start NiFi:
+To start NiFi Registry:
 - [linux/osx] execute bin/nifi-registry.sh start
-- [windows] execute bin/start-nifi-registry.bat
+- [windows] execute bin/run-nifi-registry.bat
 - Direct your browser to http://localhost:18080/nifi-registry/
 
 ## Getting Help

--- a/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/flow/Position.java
+++ b/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/flow/Position.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-@ApiModel("The position of a component on the graph")
+@ApiModel(description = "The position of a component on the graph")
 public class Position {
     private double x;
     private double y;

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/AuthorizableLookup.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/AuthorizableLookup.java
@@ -28,6 +28,13 @@ public interface AuthorizableLookup {
     Authorizable getActuatorAuthorizable();
 
     /**
+     * Get the authorizable for /swagger.
+     *
+     * @return authorizable
+     */
+    Authorizable getSwaggerAuthorizable();
+
+    /**
      * Get the authorizable for /proxy.
      *
      * @return authorizable

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/StandardAuthorizableLookup.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/StandardAuthorizableLookup.java
@@ -91,9 +91,26 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
         }
     };
 
+    private static final Authorizable SWAGGER_AUTHORIZABLE = new Authorizable() {
+        @Override
+        public Authorizable getParentAuthorizable() {
+            return null;
+        }
+
+        @Override
+        public Resource getResource() {
+            return ResourceFactory.getSwaggerResource();
+        }
+    };
+
     @Override
     public Authorizable getActuatorAuthorizable() {
         return ACTUATOR_AUTHORIZABLE;
+    }
+
+    @Override
+    public Authorizable getSwaggerAuthorizable() {
+        return SWAGGER_AUTHORIZABLE;
     }
 
     @Override
@@ -160,6 +177,9 @@ public class StandardAuthorizableLookup implements AuthorizableLookup {
                 break;
             case Actuator:
                 authorizable = getActuatorAuthorizable();
+                break;
+            case Swagger:
+                authorizable = getSwaggerAuthorizable();
                 break;
 
             /* Access to buckets can be authorized by the top-level /buckets resource or an individual /buckets/{id} resource */

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAccessPolicyProvider.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/file/FileAccessPolicyProvider.java
@@ -128,6 +128,9 @@ public class FileAccessPolicyProvider implements ConfigurableAccessPolicyProvide
             new ResourceActionPair("/actuator", READ_CODE),
             new ResourceActionPair("/actuator", WRITE_CODE),
             new ResourceActionPair("/actuator", DELETE_CODE),
+            new ResourceActionPair("/swagger", READ_CODE),
+            new ResourceActionPair("/swagger", WRITE_CODE),
+            new ResourceActionPair("/swagger", DELETE_CODE),
             new ResourceActionPair("/proxy", WRITE_CODE)
     };
 

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/resource/ResourceFactory.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/resource/ResourceFactory.java
@@ -108,6 +108,23 @@ public final class ResourceFactory {
         }
     };
 
+    private final static Resource SWAGGER_RESOURCE = new Resource() {
+        @Override
+        public String getIdentifier() {
+            return ResourceType.Swagger.getValue();
+        }
+
+        @Override
+        public String getName() {
+            return "Swagger";
+        }
+
+        @Override
+        public String getSafeDescription() {
+            return "swagger";
+        }
+    };
+
     /**
      * Gets the Resource for actuator system management endpoints.
      *
@@ -115,6 +132,15 @@ public final class ResourceFactory {
      */
     public static Resource getActuatorResource() {
         return ACTUATOR_RESOURCE;
+    }
+
+    /**
+     * Gets the Resource for swagger UI static resources.
+     *
+     * @return  The resource for swagger UI static resources.
+     */
+    public static Resource getSwaggerResource() {
+        return SWAGGER_RESOURCE;
     }
 
     /**

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/resource/ResourceType.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/resource/ResourceType.java
@@ -21,7 +21,8 @@ public enum ResourceType {
     Policy("/policies"),
     Proxy("/proxy"),
     Tenant("/tenants"),
-    Actuator("/actuator");
+    Actuator("/actuator"),
+    Swagger("/swagger");
 
     final String value;
 

--- a/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/AuthorizationService.java
+++ b/nifi-registry-framework/src/main/java/org/apache/nifi/registry/service/AuthorizationService.java
@@ -530,6 +530,9 @@ public class AuthorizationService {
         if (includeFilter == null || includeFilter.equals(ResourceType.Actuator)) {
             resources.add(ResourceFactory.getActuatorResource());
         }
+        if (includeFilter == null || includeFilter.equals(ResourceType.Swagger)) {
+            resources.add(ResourceFactory.getSwaggerResource());
+        }
         if (includeFilter == null || includeFilter.equals(ResourceType.Bucket)) {
             resources.add(ResourceFactory.getBucketsResource());
             // add all buckets

--- a/nifi-registry-framework/src/test/groovy/org/apache/nifi/registry/service/AuthorizationServiceSpec.groovy
+++ b/nifi-registry-framework/src/test/groovy/org/apache/nifi/registry/service/AuthorizationServiceSpec.groovy
@@ -536,7 +536,7 @@ class AuthorizationServiceSpec extends Specification {
 
         then:
         resources != null
-        resources.size() == 7
+        resources.size() == 8
         def sortedResources = resources.sort{it.identifier}
         sortedResources[0].identifier == "/actuator"
         sortedResources[1].identifier == "/buckets"
@@ -544,7 +544,8 @@ class AuthorizationServiceSpec extends Specification {
         sortedResources[3].identifier == "/buckets/b2"
         sortedResources[4].identifier == "/policies"
         sortedResources[5].identifier == "/proxy"
-        sortedResources[6].identifier == "/tenants"
+        sortedResources[6].identifier == "/swagger"
+        sortedResources[7].identifier == "/tenants"
 
     }
 
@@ -582,6 +583,7 @@ class AuthorizationServiceSpec extends Specification {
         authorizableLookup.getAuthorizableByResource("/buckets/b2") >> denied
         authorizableLookup.getAuthorizableByResource("/policies")   >> authorized
         authorizableLookup.getAuthorizableByResource("/proxy")      >> denied
+        authorizableLookup.getAuthorizableByResource("/swagger")    >> denied
         authorizableLookup.getAuthorizableByResource("/tenants")    >> authorized
 
 

--- a/nifi-registry-web-api/pom.xml
+++ b/nifi-registry-web-api/pom.xml
@@ -89,7 +89,7 @@
                                     <outputPath>
                                         ${project.build.directory}/${project.artifactId}-${project.version}/docs/rest-api/index.html
                                     </outputPath>
-                                    <swaggerDirectory>${project.build.directory}/swagger-ui</swaggerDirectory>
+                                    <swaggerDirectory>${project.build.directory}/swagger</swaggerDirectory>
                                 </apiSource>
                             </apiSources>
                         </configuration>
@@ -116,8 +116,115 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>download-swagger-ui</id>
+                        <!-- This plugin downloads swagger UI static assets during the build, to be
+                             served by the web app to render the dynamically generated Swagger spec.
+                             For offline development, or to build without the swagger UI, activate
+                             the "no-swagger-ui" maven profile during the build with the "-P" flag -->
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>
+                                https://github.com/swagger-api/swagger-ui/archive/v${swagger.ui.version}.tar.gz
+                            </url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${project.build.directory}
+                            </outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>bundle-swagger-ui</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <sequential>
+                                    <echo>Copy static Swagger UI files to target</echo>
+                                    <copy todir="${project.build.directory}/classes/static/swagger">
+                                        <fileset dir="${project.build.directory}/swagger-ui-${swagger.ui.version}/dist">
+                                            <include name="**"/>
+                                        </fileset>
+                                    </copy>
+                                    <echo>Disable schema validation by removing validatorUrl</echo>
+                                    <replace token="https://online.swagger.io/validator"
+                                             value=""
+                                             dir="${project.build.directory}/classes/static/swagger">
+                                        <include name="swagger-ui-bundle.js"/>
+                                        <include name="swagger-ui-standalone-preset.js"/>
+                                    </replace>
+                                    <echo>Rename 'index.html' to 'ui.html'</echo>
+                                    <move file="${project.build.directory}/classes/static/swagger/index.html"
+                                          tofile="${project.build.directory}/classes/static/swagger/ui.html"/>
+                                    <echo>Replace default swagger.json location</echo>
+                                    <replace token="http://petstore.swagger.io/v2/swagger.json"
+                                             value="/nifi-registry-api/swagger/swagger.json"
+                                             dir="${project.build.directory}/classes/static/swagger">
+                                        <include name="ui.html"/>
+                                    </replace>
+                                    <echo>Copy swagger.json into static assets folder</echo>
+                                    <copy todir="${project.build.directory}/classes/static/swagger">
+                                        <fileset dir="${project.build.directory}/swagger">
+                                            <include name="*.json"/>
+                                        </fileset>
+                                    </copy>
+                                </sequential>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>no-swagger-ui</id>
+            <!-- Activate this profile with "-P no-swagger-ui" to disable the Swagger UI
+                 static assets from being downloaded and bundled with the web api WAR. -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>1.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>download-swagger-ui</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
+                        <executions>
+                            <execution>
+                                <id>bundle-swagger-ui</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/NiFiRegistryResourceConfig.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/NiFiRegistryResourceConfig.java
@@ -69,8 +69,8 @@ public class NiFiRegistryResourceConfig extends ResourceConfig {
         // so it can directly set the HttpServletResponse instead of indirectly through a JAX-RS Response
         property(ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR, true);
 
-        // configure jersey to ignore resource paths for actuator
-        property(ServletProperties.FILTER_STATIC_CONTENT_REGEX, "/actuator.*");
+        // configure jersey to ignore resource paths for actuator and swagger-ui
+        property(ServletProperties.FILTER_STATIC_CONTENT_REGEX, "/(actuator|swagger/).*");
     }
 
 }

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/FlowResource.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/api/FlowResource.java
@@ -94,6 +94,7 @@ public class FlowResource extends AuthorizableApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
             value = "Gets a flow",
+            nickname = "globalGetFlow",
             response = VersionedFlow.class,
             extensions = {
                     @Extension(name = "access-policy", properties = {
@@ -133,6 +134,7 @@ public class FlowResource extends AuthorizableApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
             value = "Gets summary information for all versions of a flow. Versions are ordered newest->oldest.",
+            nickname = "globalGetFlowVersions",
             response = VersionedFlowSnapshotMetadata.class,
             responseContainer = "List",
             extensions = {
@@ -174,6 +176,7 @@ public class FlowResource extends AuthorizableApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
             value = "Gets the given version of a flow",
+            nickname = "globalGetFlowVersion",
             response = VersionedFlowSnapshot.class,
             extensions = {
                     @Extension(name = "access-policy", properties = {
@@ -215,6 +218,7 @@ public class FlowResource extends AuthorizableApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
             value = "Get the latest version of a flow",
+            nickname = "globalGetLatestFlowVersion",
             response = VersionedFlowSnapshot.class,
             extensions = {
                     @Extension(name = "access-policy", properties = {
@@ -253,6 +257,7 @@ public class FlowResource extends AuthorizableApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
             value = "Get the metadata for the latest version of a flow",
+            nickname = "globalGetLatestFlowVersionMetadata",
             response = VersionedFlowSnapshotMetadata.class,
             extensions = {
                     @Extension(name = "access-policy", properties = {

--- a/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
+++ b/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/NiFiRegistrySecurityConfig.java
@@ -165,6 +165,7 @@ public class NiFiRegistrySecurityConfig extends WebSecurityConfigurerAdapter {
             resourceAuthorizationFilter = ResourceAuthorizationFilter.builder()
                     .setAuthorizationService(authorizationService)
                     .addResourceType(ResourceType.Actuator)
+                    .addResourceType(ResourceType.Swagger)
                     .build();
         }
         return resourceAuthorizationFilter;

--- a/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/SecureFileIT.java
+++ b/nifi-registry-web-api/src/test/java/org/apache/nifi/registry/web/api/SecureFileIT.java
@@ -86,6 +86,7 @@ public class SecureFileIT extends IntegrationTestBase {
         // Given: an empty registry returns these resources
         String expected = "[" +
                 "{\"identifier\":\"/actuator\",\"name\":\"Actuator\"}," +
+                "{\"identifier\":\"/swagger\",\"name\":\"Swagger\"}," +
                 "{\"identifier\":\"/policies\",\"name\":\"Access Policies\"}," +
                 "{\"identifier\":\"/tenants\",\"name\":\"Tenants\"}," +
                 "{\"identifier\":\"/proxy\",\"name\":\"Proxy User Requests\"}," +

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         <spring.boot.version>2.0.2.RELEASE</spring.boot.version>
         <spring.security.version>5.0.5.RELEASE</spring.security.version>
         <flyway.version>4.2.0</flyway.version>
+        <swagger.ui.version>3.12.0</swagger.ui.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Contains the following changes:

- Adds self-hosted Swagger UI to nifi-registry-web-api WAR at /swagger/ui.html
- Updates NOTICE for included ALv2 licensed source
- Adds Jersey filter exclusion for resources starting with /swagger/*
- Adds top-level authorizable resource type for /swagger/*
- Updates ResourceAuthorizationFilter configuration to include swagger resource type
- Corrects name of Position model object in Swagger specification
- Corrects duplicate operationId/nickname field for methods in FlowResource and BucketFlowResource

For reviewers:

- Verify /nifi-registry-api/swagger/ui.html is accessible and working in unsecured mode.
- Verify /nifi-registry-api/swagger/swagger.json returns a good Swagger spec.
- In secured mode, an initial admin should have access, as should any user who is granted read access to the "/swagger" resource
- Verify changes to NOTICE in source code and nifi-registry-assembly


