### PR TITLE
NIFIREG-198 Fix VersionedRemoteProcessGroup targetUri bug

### DIFF
--- a/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/flow/VersionedRemoteProcessGroup.java
+++ b/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/flow/VersionedRemoteProcessGroup.java
@@ -17,9 +17,10 @@
 
 package org.apache.nifi.registry.flow;
 
-import java.util.Set;
-
 import io.swagger.annotations.ApiModelProperty;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Set;
 
 public class VersionedRemoteProcessGroup extends VersionedComponent {
     private String targetUri;
@@ -36,47 +37,39 @@ public class VersionedRemoteProcessGroup extends VersionedComponent {
     private Set<VersionedRemoteGroupPort> inputPorts;
     private Set<VersionedRemoteGroupPort> outputPorts;
 
+    @ApiModelProperty(
+            value = "The target URI of the remote process group." +
+                    " If target uri is not set, but uris are set, then returns the first uri in the uris." +
+                    " If neither target uri nor uris are set, then returns null.")
+    public String getTargetUri() {
+
+        if (!StringUtils.isEmpty(targetUri)) {
+            return targetUri;
+        }
+        return !StringUtils.isEmpty(targetUris) ? targetUris.split(",", 2)[0] : null;
+
+    }
 
     public void setTargetUri(final String targetUri) {
         this.targetUri = targetUri;
     }
 
+    @ApiModelProperty(
+            value = "The target URIs of the remote process group." +
+                    " If target uris is not set but target uri is set, then returns the single target uri." +
+                    " If neither target uris nor target uri is set, then returns null.")
+    public String getTargetUris() {
 
-    @ApiModelProperty("The target URI of the remote process group." +
-        " If target uri is not set, but uris are set, then returns the first url in the urls." +
-        " If neither target uri nor uris are set, then returns null.")
-    public String getTargetUri() {
-        if (targetUri != null && targetUri.length() > 0) {
-            return targetUri;
+        if (!StringUtils.isEmpty(targetUris)) {
+            return targetUris;
         }
-        if (targetUris == null || targetUris.length() == 0) {
-            return null;
-        }
+        return !StringUtils.isEmpty(targetUri) ? targetUri : null;
 
-        if (targetUris.contains(",")) {
-            return targetUris.substring(0, targetUris.indexOf(','));
-        }
-
-        return this.targetUri;
     }
 
     public void setTargetUris(String targetUris) {
         this.targetUris = targetUris;
     }
-
-
-    @ApiModelProperty("The target URI of the remote process group." +
-        " If target uris is not set but target uri is set," +
-        " then returns the single target uri." +
-        " If neither target uris nor target uri is set, then returns null.")
-    public String getTargetUris() {
-        if (targetUris == null || targetUris.length() == 0) {
-            return targetUri;
-        }
-
-        return this.targetUris;
-    }
-
 
     @ApiModelProperty("The time period used for the timeout when communicating with the target.")
     public String getCommunicationsTimeout() {

--- a/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/flow/VersionedRemoteProcessGroup.java
+++ b/nifi-registry-data-model/src/main/java/org/apache/nifi/registry/flow/VersionedRemoteProcessGroup.java
@@ -37,10 +37,14 @@ public class VersionedRemoteProcessGroup extends VersionedComponent {
     private Set<VersionedRemoteGroupPort> inputPorts;
     private Set<VersionedRemoteGroupPort> outputPorts;
 
+
+    @Deprecated
     @ApiModelProperty(
-            value = "The target URI of the remote process group." +
+            value = "[DEPRECATED] The target URI of the remote process group." +
                     " If target uri is not set, but uris are set, then returns the first uri in the uris." +
-                    " If neither target uri nor uris are set, then returns null.")
+                    " If neither target uri nor uris are set, then returns null.",
+            notes = "This field is deprecated and will be removed in version 1.x of NiFi Registry." +
+                    " Please migrate to using targetUris only.")
     public String getTargetUri() {
 
         if (!StringUtils.isEmpty(targetUri)) {

--- a/nifi-registry-data-model/src/test/java/org/apache/nifi/registry/flow/TestVersionedRemoteProcessGroup.java
+++ b/nifi-registry-data-model/src/test/java/org/apache/nifi/registry/flow/TestVersionedRemoteProcessGroup.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.flow;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestVersionedRemoteProcessGroup {
+
+    @Test
+    public void testGetTargetUriAndGetTargetUris() {
+
+        VersionedRemoteProcessGroup vRPG = new VersionedRemoteProcessGroup();
+
+
+        /* targetUri is null, targetUris varies */
+
+        vRPG.setTargetUri(null);
+        vRPG.setTargetUris(null);
+        assertEquals(null, vRPG.getTargetUri());
+        assertEquals(null, vRPG.getTargetUris());
+
+        vRPG.setTargetUri(null);
+        vRPG.setTargetUris("");
+        assertEquals(null, vRPG.getTargetUri());
+        assertEquals(null, vRPG.getTargetUris());
+
+        vRPG.setTargetUri(null);
+        vRPG.setTargetUris("uri-2");
+        //assertEquals("uri-2", vRPG.getTargetUri());
+        assertEquals("uri-2", vRPG.getTargetUris());
+
+        vRPG.setTargetUri(null);
+        vRPG.setTargetUris("uri-2,uri-3");
+        assertEquals("uri-2", vRPG.getTargetUri());
+        assertEquals("uri-2,uri-3", vRPG.getTargetUris());
+
+
+        /* targetUri is empty, targetUris varies */
+
+        vRPG.setTargetUri("");
+        vRPG.setTargetUris(null);
+        assertEquals(null, vRPG.getTargetUri());
+        assertEquals(null, vRPG.getTargetUris());
+
+        vRPG.setTargetUri("");
+        vRPG.setTargetUris("");
+        assertEquals(null, vRPG.getTargetUri());
+        assertEquals(null, vRPG.getTargetUris());
+
+        vRPG.setTargetUri("");
+        vRPG.setTargetUris("uri-2");
+        assertEquals("uri-2", vRPG.getTargetUri());
+        assertEquals("uri-2", vRPG.getTargetUris());
+
+        vRPG.setTargetUri("");
+        vRPG.setTargetUris("uri-2,uri-3");
+        assertEquals("uri-2", vRPG.getTargetUri());
+        assertEquals("uri-2,uri-3", vRPG.getTargetUris());
+
+
+        /* targetUri is set, targetUris varies */
+
+        vRPG.setTargetUri("uri-1");
+        vRPG.setTargetUris(null);
+        assertEquals("uri-1", vRPG.getTargetUri());
+        assertEquals("uri-1", vRPG.getTargetUris());
+
+        vRPG.setTargetUri("uri-1");
+        vRPG.setTargetUris("");
+        assertEquals("uri-1", vRPG.getTargetUri());
+        assertEquals("uri-1", vRPG.getTargetUris());
+
+        vRPG.setTargetUri("uri-1");
+        vRPG.setTargetUris("uri-2");
+        assertEquals("uri-1", vRPG.getTargetUri());
+        assertEquals("uri-2", vRPG.getTargetUris());
+
+        vRPG.setTargetUri("uri-1");
+        vRPG.setTargetUris("uri-2,uri-3");
+        assertEquals("uri-1", vRPG.getTargetUri());
+        assertEquals("uri-2,uri-3", vRPG.getTargetUris());
+
+    }
+
+
+}


### PR DESCRIPTION
VersionedRemoteProcessGroup has two fields: targetUri and targetUris. They do not have simple getters, but rather each will fallback to using the other. Given how they are described, for certain combinations of targetUri and targetUris, they do not work correctly (mainly, when targetUri is not set and targetUris contains only a single value).

Furthermore, in NiFi only TargetUris is used/needed. It was a replacement for targetUri when the requirement for multiple URIs was added. Therefore, in addition to fixing the bug descirbed above, targetUri can be deprecated and dropped in future versions of NiFi Registry.