### PR TITLE
NIFIREG-200 Update dependencies

### DIFF
--- a/nifi-registry-web-api/pom.xml
+++ b/nifi-registry-web-api/pom.xml
@@ -312,11 +312,6 @@
             <artifactId>jjwt</artifactId>
             <version>0.7.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.apache.nifi.registry</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,12 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2017</inceptionYear>
         <org.slf4j.version>1.7.12</org.slf4j.version>
-        <jetty.version>9.4.3.v20170317</jetty.version>
+        <jetty.version>9.4.11.v20180605</jetty.version>
         <jax.rs.api.version>2.1</jax.rs.api.version>
         <jersey.version>2.26</jersey.version>
-        <jackson.version>2.9.2</jackson.version>
-        <spring.boot.version>2.0.2.RELEASE</spring.boot.version>
-        <spring.security.version>5.0.5.RELEASE</spring.security.version>
+        <jackson.version>2.9.6</jackson.version>
+        <spring.boot.version>2.0.4.RELEASE</spring.boot.version>
+        <spring.security.version>5.0.7.RELEASE</spring.security.version>
         <flyway.version>4.2.0</flyway.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
     </properties>


### PR DESCRIPTION
- Update Jetty to version 9.4.11.v20180605
- Update Spring Boot to version 2.0.4.RELEASE
- Update Spring Security to version 5.0.7.RELEASE
- Update Jackson to version 2.9.6
- Drop Guava (was unused) from nifi-registry-web-api