### PR TITLE
Bugfix overriding flow provider via environment variables (Docker)

### DIFF
--- a/nifi-registry-core/nifi-registry-docker/dockerhub/sh/update_flow_provider.sh
+++ b/nifi-registry-core/nifi-registry-docker/dockerhub/sh/update_flow_provider.sh
@@ -23,7 +23,9 @@ add_property() {
   property_value=$2
 
   if [ -n "${property_value}" ]; then
-    xmlstarlet ed --subnode "/providers/flowPersistenceProvider" --type elem -n property -v "${property_value}" providers.xml | xmlstarlet ed --subnode "/providers/flowPersistenceProvider/property[not(name)]" --type attr -n name -v "${property_name}"
+    xmlstarlet ed --inplace --subnode "${property_xpath}" --type elem -n property -v "${property_value}" \
+      -i \$prev --type attr -n name -v "${property_name}" \
+      "${providers_file}"
   fi
 }
 


### PR DESCRIPTION
The script which maps env to flow provider properties is currently not overwriting the file, but instead sending to stdout. This should fix the issue in the Docker update_flow_provider script.

Note: This replicates a fix also made in https://github.com/apache/nifi-registry/pull/132