### PR TITLE
NIFIREG-229: Handle error in LDAP sync background thread

### DIFF
--- a/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authorization/Group.java
+++ b/nifi-registry-core/nifi-registry-security-api/src/main/java/org/apache/nifi/registry/security/authorization/Group.java
@@ -89,7 +89,7 @@ public class Group {
 
     @Override
     public String toString() {
-        return String.format("identifier[%s], name[%s]", getIdentifier(), getName());
+        return String.format("identifier[%s], name[%s], users[%s]", getIdentifier(), getName(), String.join(", ", users));
     }
 
 


### PR DESCRIPTION
- Catch thrown errors and exceptions in background ldap sync task to prevent killing the thread
- Improve logging by moving some warns to debug for potentially valid configurations and add more debug output.