### PR TITLE
NIFIREG-230 Fix Typo In dockerhub README

### DIFF
--- a/nifi-registry-core/nifi-registry-docker/dockerhub/README.md
+++ b/nifi-registry-core/nifi-registry-docker/dockerhub/README.md
@@ -26,7 +26,7 @@ The Docker image can be built using the following command:
     # user @ puter in ~/path/to/apache/nifi-registry/nifi-registry-docker/dockerhub    
     $ docker build -t apache/nifi-registry:latest .
 
-This will result in an image tagged apache/nifi:latest
+This will result in an image tagged apache/nifi-registry:latest
 
     $ docker images
     > REPOSITORY               TAG           IMAGE ID            CREATED                  SIZE


### PR DESCRIPTION
The README.md file in the dockerhub directory suggests that the NiFi
Registry image is tagged as 'apache/nifi:latest' instead of
'apache/nifi-registry:latest'. This seems to be a typo.