### PR TITLE
NIFIREG-253 Updated KerberosIdentityProvider to use the "Default Real…

### DIFF
--- a/nifi-registry-core/nifi-registry-security-utils/pom.xml
+++ b/nifi-registry-core/nifi-registry-security-utils/pom.xml
@@ -37,6 +37,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>1.0-groovy-2.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/nifi-registry-core/nifi-registry-security-utils/src/main/java/org/apache/nifi/registry/security/util/kerberos/KerberosPrincipalParser.java
+++ b/nifi-registry-core/nifi-registry-security-utils/src/main/java/org/apache/nifi/registry/security/util/kerberos/KerberosPrincipalParser.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.security.util.kerberos;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class KerberosPrincipalParser {
+
+    /**
+     * <p>Determines the realm specified in the given kerberos principal.
+     *
+     * <p>The content of the given {@code principal} after the occurrence
+     * of the last non-escaped realm delimiter ("@") will be considered
+     * the realm of the principal.
+     *
+     * <p>The validity of the given {@code principal} and the determined realm
+     * is not be verified by this method.
+     *
+     * @param principal the principal for which the realm will be determined
+     * @return the realm of the given principal
+     */
+    public static String getRealm(String principal) {
+        if (StringUtils.isBlank(principal)) {
+            throw new IllegalArgumentException("principal can not be null or empty");
+        }
+
+        char previousChar = 0;
+        int realmDelimiterIndex = -1;
+        char currentChar;
+        boolean realmDelimiterFound = false;
+        int principalLength = principal.length();
+
+        // find the last non-escaped occurrence of the realm delimiter
+        for (int i = 0; i < principalLength; ++i) {
+            currentChar = principal.charAt(i);
+            if (currentChar == '@' && previousChar != '\\' ) {
+                realmDelimiterIndex = i;
+                realmDelimiterFound = true;
+            }
+            previousChar = currentChar;
+        }
+
+        String principalAfterLastRealmDelimiter = principal.substring(realmDelimiterIndex + 1);
+        return realmDelimiterFound && realmDelimiterIndex + 1 < principalLength ? principalAfterLastRealmDelimiter : null;
+    }
+}

--- a/nifi-registry-core/nifi-registry-security-utils/src/test/groovy/org/apache/nifi/registry/security/util/kerberos/KerberosPrincipalParserSpec.groovy
+++ b/nifi-registry-core/nifi-registry-security-utils/src/test/groovy/org/apache/nifi/registry/security/util/kerberos/KerberosPrincipalParserSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.security.util.kerberos
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class KerberosPrincipalParserSpec extends Specification {
+
+    @Unroll
+    def "Verify parsed realm from '#testPrincipal' == '#expectedRealm'"() {
+        expect:
+        KerberosPrincipalParser.getRealm(testPrincipal) == expectedRealm
+
+        where:
+        testPrincipal                     || expectedRealm
+        "user"                            || null
+        "user@"                           || null
+        "user@EXAMPLE.COM"                || "EXAMPLE.COM"
+        "user@name@EXAMPLE.COM"           || "EXAMPLE.COM"
+        "user\\@"                         || null
+        "user\\@name"                     || null
+        "user\\@name@EXAMPLE.COM"         || "EXAMPLE.COM"
+        "user@EXAMPLE.COM\\@"             || "EXAMPLE.COM\\@"
+        "user@@name@\\@@\\@"              || "\\@"
+        "user@@name@\\@@\\@@EXAMPLE.COM"  || "EXAMPLE.COM"
+        "user@@name@\\@@\\@@EXAMPLE.COM@" || null
+        "user\\@\\@name@EXAMPLE.COM"      || "EXAMPLE.COM"
+    }
+}

--- a/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/kerberos/KerberosIdentityProvider.java
+++ b/nifi-registry-core/nifi-registry-web-api/src/main/java/org/apache/nifi/registry/web/security/authentication/kerberos/KerberosIdentityProvider.java
@@ -68,7 +68,7 @@ public class KerberosIdentityProvider extends BasicAuthIdentityProvider {
         }
 
         defaultRealm = configurationContext.getProperty("Default Realm");
-        if (defaultRealm.contains("@")) {
+        if (StringUtils.isNotBlank(defaultRealm) && defaultRealm.contains("@")) {
             throw new SecurityProviderCreationException(String.format("The Default Realm '%s' must not contain \"@\"", defaultRealm));
         }
 


### PR DESCRIPTION
…m" property

  Implemented prioritized handling of appending the default realm
    A realm-qualified principal will not be modified before authentication
    A principal shortname will have Default Realm appended to it when it is not blank before authentication
    A principal shortname will not be modified if Default Realm is blank, and the underlying kerberos implementation will append the default_realm configured in krb5.conf
In nifi-registry-security-utils
  added KerberosPrincipalParser for determining the realm of a kerberos principal
  added tests for KerberosPrincipalParser
  updated pom with spock-core as a test dependency


**Note:** KerberosPrincipalParser should be run from an IDE, due to https://issues.apache.org/jira/browse/NIFIREG-255