### PR TITLE
NIFIREG-286 - Upgrading various dependencies

### DIFF
--- a/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -246,7 +246,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.55</version>
+            <version>1.61</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -294,12 +294,17 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.196</version>
+            <version>1.4.199</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>4.11.0.201803080745-r</version>
+            <version>5.4.0.201906121030-r</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>com.jcraft</groupId>
@@ -314,7 +319,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/nifi-registry-core/nifi-registry-properties/pom.xml
+++ b/nifi-registry-core/nifi-registry-properties/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.55</version>
+            <version>1.61</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/nifi-registry-core/nifi-registry-properties/src/test/groovy/org/apache/nifi/registry/properties/AESSensitivePropertyProviderTest.groovy
+++ b/nifi-registry-core/nifi-registry-properties/src/test/groovy/org/apache/nifi/registry/properties/AESSensitivePropertyProviderTest.groovy
@@ -277,9 +277,10 @@ class AESSensitivePropertyProviderTest extends GroovyTestCase {
             SensitivePropertyProvider spp = new AESSensitivePropertyProvider(Hex.decode(getKeyOfSize(keySize)))
             logger.info("Initialized ${spp.name} with key size ${keySize}")
             String cipherText = spp.protect(PLAINTEXT)
+
             // Remove the IV from the "complete" cipher text
             final String MISSING_IV_CIPHER_TEXT = cipherText[18..-1]
-            logger.info("Manipulated ${cipherText} to\n${MISSING_IV_CIPHER_TEXT.padLeft(163)}")
+            logger.info("Manipulated ${cipherText} to\n${MISSING_IV_CIPHER_TEXT.padLeft(172)}")
 
             def msg = shouldFail(IllegalArgumentException) {
                 spp.unprotect(MISSING_IV_CIPHER_TEXT)
@@ -288,9 +289,9 @@ class AESSensitivePropertyProviderTest extends GroovyTestCase {
 
             // Remove the IV from the "complete" cipher text but keep the delimiter
             final String MISSING_IV_CIPHER_TEXT_WITH_DELIMITER = cipherText[16..-1]
-            logger.info("Manipulated ${cipherText} to\n${MISSING_IV_CIPHER_TEXT_WITH_DELIMITER.padLeft(163)}")
+            logger.info("Manipulated ${cipherText} to\n${MISSING_IV_CIPHER_TEXT_WITH_DELIMITER.padLeft(172)}")
 
-            def msgWithDelimiter = shouldFail(DecoderException) {
+            def msgWithDelimiter = shouldFail(IllegalArgumentException) {
                 spp.unprotect(MISSING_IV_CIPHER_TEXT_WITH_DELIMITER)
             }
             logger.expected("${msgWithDelimiter} for keySize ${keySize} and cipher text [${MISSING_IV_CIPHER_TEXT_WITH_DELIMITER}]")
@@ -299,7 +300,7 @@ class AESSensitivePropertyProviderTest extends GroovyTestCase {
             assert msg == "The cipher text does not contain the delimiter || -- it should be of the form Base64(IV) || Base64(cipherText)"
 
             // Assert
-            assert msgWithDelimiter =~ "unable to decode base64 string"
+            assert msgWithDelimiter == "The IV (0 bytes) must be at least 12 bytes"
         }
     }
 

--- a/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/logback.xml
+++ b/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/logback.xml
@@ -17,10 +17,10 @@
     <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
         <resetJUL>true</resetJUL>
     </contextListener>
-    
+
     <appender name="APP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-app.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!--
               For daily rollover, use 'app_%d.log'.
               For hourly rollover, use 'app_%d{yyyy-MM-dd_HH}.log'.
@@ -28,15 +28,15 @@
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
             <fileNamePattern>${org.apache.nifi.registry.bootstrap.config.log.dir}/nifi-registry-app_%d{yyyy-MM-dd_HH}.%i.log</fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>100MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxFileSize>100MB</maxFileSize>
             <!-- keep 30 log files worth of history -->
             <maxHistory>30</maxHistory>
+            <!-- keep 10GB total of log files -->
+            <totalSizeCap>10GB</totalSizeCap>
         </rollingPolicy>
+        <immediateFlush>true</immediateFlush>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>%date %level [%thread] %logger{40} %msg%n</pattern>
-            <immediateFlush>true</immediateFlush>
         </encoder>
     </appender>
 

--- a/nifi-registry-core/nifi-registry-security-utils/pom.xml
+++ b/nifi-registry-core/nifi-registry-security-utils/pom.xml
@@ -26,12 +26,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.55</version>
+            <version>1.61</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.55</version>
+            <version>1.61</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/nifi-registry-core/pom.xml
+++ b/nifi-registry-core/pom.xml
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <jax.rs.api.version>2.1</jax.rs.api.version>
         <jersey.version>2.27</jersey.version>
         <jackson.version>2.9.8</jackson.version>
+        <jackson.databind.version>2.9.9.1</jackson.databind.version>
         <spring.boot.version>2.1.3.RELEASE</spring.boot.version>
         <spring.security.version>5.1.3.RELEASE</spring.security.version>
         <flyway.version>5.2.1</flyway.version>
@@ -158,7 +159,7 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.1.3</version>
+                <version>1.2.3</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
@@ -419,12 +420,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.15</version>
+                    <version>3.0.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>6.5</version>
+                            <version>8.21</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -535,13 +536,11 @@
                                     <property name="processJavadoc" value="true" />
                                 </module>
                                 <module name="NoLineWrap" />
-                                <module name="LeftCurly">
-                                    <property name="maxLineLength" value="160" />
-                                </module>
+                                <module name="LeftCurly" />
                                 <module name="RightCurly" />
                                 <module name="RightCurly">
-                                    <property name="option" value="alone" />
-                                    <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT" />
+                                    <property name="option" value="alone_or_singleline" />
+                                    <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT" />
                                 </module>
                                 <module name="SeparatorWrap">
                                     <property name="tokens" value="DOT" />
@@ -571,6 +570,7 @@
                                 </module>
                                 <module name="NonEmptyAtclauseDescription" />
                                 <module name="JavadocMethod">
+                                    <property name="allowUndeclaredRTE" value="true" />
                                     <property name="allowMissingJavadoc" value="true" />
                                     <property name="allowMissingParamTags" value="true" />
                                     <property name="allowMissingThrowsTags" value="true" />


### PR DESCRIPTION
NIFIREG-286 - Upgraded bouncycastle deps

NIFIREG-286 - Upgraded h2 database deps

NIFIREG-286 - Upgraded jgit dependency. Had to include commons-codec:1.12 as without this I was seeing missing class errors.

NIFIREG-286 - Upgraded jackson-databind dependency version.

NIFIREG-286 - Upgraded logback-classic dependency.

NIFIREG-286 - Upgraded puppycrawl and maven-checkstyle-plugin versions. Minor adjustments to checkstyle rules as a result.