### PR TITLE
NIFIREG-303 Fix translation config file parsing

### DIFF
--- a/nifi-registry-core/nifi-registry-web-ui/pom.xml
+++ b/nifi-registry-core/nifi-registry-web-ui/pom.xml
@@ -206,6 +206,7 @@
                                         <include>vendor.min*.css*</include>
                                         <include>index.html</include>
                                         <include>assets/**/*</include>
+                                        <include>locale/**/*</include>
                                         <include>registry-favicon.png</include>
                                         <include>LICENSE</include>
                                         <include>NOTICE</include>

--- a/nifi-registry-core/nifi-registry-web-ui/src/main/locale/messages.es.xlf
+++ b/nifi-registry-core/nifi-registry-web-ui/src/main/locale/messages.es.xlf
@@ -89,6 +89,12 @@
         <note priority="1" from="description">A button for attempting to authenticate with the registry.</note>
         <note priority="1" from="meaning">Log in form</note>
        </trans-unit>
+      <trans-unit id="nf-cancel-user-login-button" datatype="html">
+         <source>Cancel</source>
+         <target state="new">Cancelar</target>
+        <note priority="1" from="description">A button for cancelling authentication with the registry.</note>
+        <note priority="1" from="meaning">Cancel Log in form</note>
+       </trans-unit>
       <trans-unit id="nf-admin-workflow-create-new-group-button" datatype="html">
          <source>Create</source>
          <target state="new">Crear</target>

--- a/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/nf-registry-bootstrap.js
+++ b/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/nf-registry-bootstrap.js
@@ -43,19 +43,18 @@ const locale = navigator.language.toLowerCase();
 const providers = [];
 
 // No locale or U.S. English: no translation providers so go ahead and bootstrap the app
-if (!locale || locale === 'en-us') {
+if (!locale || locale === 'en-US') {
     bootstrapModule();
 } else { //load the translation providers and bootstrap the module
-    var translationFile = 'assets/locale/messages.' + locale + '.xlf';
+    var translationFile = 'locale/messages.' + locale + '.xlf';
 
     $.ajax({
-        url: translationFile
+        url: translationFile,
+        dataType : "text"
     }).done(function (translations) {
         // add providers if translation file for locale is loaded
         if (translations) {
-            var parser = new DOMParser();
-            var translationsDom = parser.parseFromString(translations, 'text/xml');
-            providers.push({provide: TRANSLATIONS, useValue: translationsDom.documentElement.innerHTML});
+            providers.push({provide: TRANSLATIONS, useValue: translations});
             providers.push({provide: TRANSLATIONS_FORMAT, useValue: 'xlf'});
             providers.push({provide: LOCALE_ID, useValue: locale});
         }

--- a/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/nf-registry-bootstrap.js
+++ b/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/nf-registry-bootstrap.js
@@ -50,7 +50,7 @@ if (!locale || locale === 'en-US') {
 
     $.ajax({
         url: translationFile,
-        dataType : "text"
+        dataType: 'text'
     }).done(function (translations) {
         // add providers if translation file for locale is loaded
         if (translations) {

--- a/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/nf-registry-bootstrap.js
+++ b/nifi-registry-core/nifi-registry-web-ui/src/main/webapp/nf-registry-bootstrap.js
@@ -53,7 +53,9 @@ if (!locale || locale === 'en-us') {
     }).done(function (translations) {
         // add providers if translation file for locale is loaded
         if (translations) {
-            providers.push({provide: TRANSLATIONS, useValue: translations.documentElement.innerHTML});
+            var parser = new DOMParser();
+            var translationsDom = parser.parseFromString(translations, 'text/xml');
+            providers.push({provide: TRANSLATIONS, useValue: translationsDom.documentElement.innerHTML});
             providers.push({provide: TRANSLATIONS_FORMAT, useValue: 'xlf'});
             providers.push({provide: LOCALE_ID, useValue: locale});
         }


### PR DESCRIPTION
The existing code expects `translations` to be a DOM object, but it's actually a string. We need to parse it.

With this PR, I confirmed the translation works as expected.
![image](https://user-images.githubusercontent.com/1107620/62911931-19c21b80-bdc1-11e9-84c8-c85a9a3307bc.png)

To test, configure your browser language to Spanish:
![image](https://user-images.githubusercontent.com/1107620/62911954-39f1da80-bdc1-11e9-8065-747d3d7b1cd4.png)
