### PR TITLE
NIFIREG-310: Support case insensitive membership decisions in LdapUserGroupProvider

### DIFF
--- a/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -295,6 +295,7 @@ This will sync users and groups from a directory server and will present them in
 |`Url`| Space-separated list of URLs of the LDAP servers (i.e. `ldap://<hostname>:<port>`).
 |`Page Size`| Sets the page size when retrieving users and groups. If not specified, no paging is performed.
 |`Sync Interval`| Duration of time between syncing users and groups. (i.e. `30 mins`).
+|`Group Membership - Enforce Case Sensitivity` | Sets whether group membership decisions are case sensitive. When a user or group is inferred (by not specifying or user or group search base or user identity attribute or group name attribute) case sensitivity is enforced since the value to use for the user identity or group name would be ambiguous. Defaults to false.
 |`User Search Base`| Base DN for searching for users (i.e. `ou=users,o=nifi`). Required to search users.
 |`User Object Class`| Object class for identifying users (i.e. `person`). Required if searching users.
 |`User Search Scope`| Search scope for searching users (`ONE_LEVEL`, `OBJECT`, or `SUBTREE`). Required if searching users.
@@ -492,6 +493,7 @@ An Authorizer using an LdapUserGroupProvider would be configured as:
         <property name="Url">ldap://localhost:10389</property>
         <property name="Page Size"></property>
         <property name="Sync Interval">30 mins</property>
+        <property name="Group Membership - Enforce Case Sensitivity">false</property>
 
         <property name="User Search Base">ou=users,o=nifi</property>
         <property name="User Object Class">person</property>
@@ -569,6 +571,7 @@ the member attribute of each group. The users from LDAP will be read only while 
         <property name="Url">ldap://localhost:10389</property>
         <property name="Page Size"></property>
         <property name="Sync Interval">30 mins</property>
+        <property name="Group Membership - Enforce Case Sensitivity">false</property>
 
         <property name="User Search Base">ou=users,o=nifi</property>
         <property name="User Object Class">person</property>

--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/ldap/tenants/LdapUserGroupProvider.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/ldap/tenants/LdapUserGroupProvider.java
@@ -96,6 +96,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
     public static final String PROP_REFERRAL_STRATEGY = "Referral Strategy";
     public static final String PROP_URL = "Url";
     public static final String PROP_PAGE_SIZE = "Page Size";
+    public static final String PROP_GROUP_MEMBERSHIP_ENFORCE_CASE_SENSITIVITY = "Group Membership - Enforce Case Sensitivity";
 
     public static final String PROP_USER_SEARCH_BASE = "User Search Base";
     public static final String PROP_USER_OBJECT_CLASS = "User Object Class";
@@ -112,7 +113,6 @@ public class LdapUserGroupProvider implements UserGroupProvider {
     public static final String PROP_GROUP_NAME_ATTRIBUTE = "Group Name Attribute";
     public static final String PROP_GROUP_MEMBER_ATTRIBUTE = "Group Member Attribute";
     public static final String PROP_GROUP_MEMBER_REFERENCED_USER_ATTRIBUTE = "Group Member Attribute - Referenced User Attribute";
-
 
     public static final String PROP_SYNC_INTERVAL = "Sync Interval";
 
@@ -144,6 +144,8 @@ public class LdapUserGroupProvider implements UserGroupProvider {
     private boolean performGroupSearch;
 
     private Integer pageSize;
+
+    private boolean groupMembershipEnforceCaseSensitivity;
 
     @Override
     public void initialize(final UserGroupProviderInitializationContext initializationContext) throws SecurityProviderCreationException {
@@ -349,6 +351,10 @@ public class LdapUserGroupProvider implements UserGroupProvider {
             pageSize = rawPageSize.asInteger();
         }
 
+        // get whether group membership should be case sensitive
+        final String rawGroupMembershipEnforceCaseSensitivity = configurationContext.getProperty(PROP_GROUP_MEMBERSHIP_ENFORCE_CASE_SENSITIVITY).getValue();
+        groupMembershipEnforceCaseSensitivity = Boolean.parseBoolean(rawGroupMembershipEnforceCaseSensitivity);
+
         // extract the identity mappings from nifi-registry.properties if any are provided
         identityMappings = Collections.unmodifiableList(IdentityMappingUtil.getIdentityMappings(properties));
         groupMappings = Collections.unmodifiableList(IdentityMappingUtil.getGroupMappings(properties));
@@ -509,8 +515,22 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                                     try {
                                         final NamingEnumeration<String> groupValues = (NamingEnumeration<String>) attributeGroups.getAll();
                                         while (groupValues.hasMoreElements()) {
-                                            // store the group -> user identifier mapping
-                                            groupToUserIdentifierMappings.computeIfAbsent(groupValues.next(), g -> new HashSet<>()).add(user.getIdentifier());
+                                            final String groupValue = groupValues.next();
+
+                                            // if we are performing a group search, then we need to normalize the group value so that each
+                                            // user associating with it can be matched. if we are not performing a group search then these
+                                            // values will be used to actually build the group itself. case sensitivity is for group
+                                            // membership, not group identification.
+                                            final String groupValueNormalized;
+                                            if (performGroupSearch) {
+                                                groupValueNormalized = groupMembershipEnforceCaseSensitivity ? groupValue : groupValue.toLowerCase();
+                                            } else {
+                                                groupValueNormalized = groupValue;
+                                            }
+
+                                            // store the group -> user identifier mapping... if case sensitivity is disabled, the group reference value will
+                                            // be lowercased when adding to groupToUserIdentifierMappings
+                                            groupToUserIdentifierMappings.computeIfAbsent(groupValueNormalized, g -> new HashSet<>()).add(user.getIdentifier());
                                         }
                                     } catch (NamingException e) {
                                         throw new AuthorizationAccessException("Error while retrieving user group name attribute [" + userIdentityAttribute + "].");
@@ -570,8 +590,11 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                                             final String userValue = userValues.next();
 
                                             if (performUserSearch) {
-                                                // find the user by it's referenced attribute and add the identifier to this group
-                                                final User user = userLookup.get(userValue);
+                                                // find the user by it's referenced attribute and add the identifier to this group.
+                                                // need to normalize here based on the desired case sensitivity. if case sensitivity
+                                                // is disabled, the user reference value will be lowercased when adding to userLookup
+                                                final String userValueNormalized = groupMembershipEnforceCaseSensitivity ? userValue : userValue.toLowerCase();
+                                                final User user = userLookup.get(userValueNormalized);
 
                                                 // ensure the user is known
                                                 if (user != null) {
@@ -582,13 +605,16 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                                                             "Ignoring group membership.", name, userValue));
                                                 }
                                             } else {
-                                                // since performUserSearch is false, then the referenced group attribute must be blank... the user value must be the dn
+                                                // since performUserSearch is false, then the referenced group attribute must be blank... the user value must be the dn.
+                                                // no need to normalize here since group membership is driven solely through this group (not through the userLookup
+                                                // populated above). we are either going to use this value directly as the user identity or we are going to query
+                                                // the directory server again which should handle the case sensitivity accordingly.
                                                 final String userDn = userValue;
 
                                                 final String userIdentity;
                                                 if (useDnForUserIdentity) {
                                                     // use the user value to avoid the unnecessary look up
-                                                    userIdentity = userDn;
+                                                    userIdentity = IdentityMappingUtil.mapIdentity(userDn, identityMappings);
                                                 } else {
                                                     // lookup the user to extract the user identity
                                                     userIdentity = getUserIdentity((DirContextAdapter) ldapTemplate.lookup(userDn));
@@ -635,7 +661,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
                     final String groupName;
                     if (useDnForGroupName) {
                         // use the dn to avoid the unnecessary look up
-                        groupName = groupDn;
+                        groupName = IdentityMappingUtil.mapIdentity(groupDn, groupMappings);
                     } else {
                         groupName = getGroupName((DirContextAdapter) ldapTemplate.lookup(groupDn));
                     }
@@ -711,7 +737,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
             }
         }
 
-        return referencedUserValue;
+        return groupMembershipEnforceCaseSensitivity ? referencedUserValue : referencedUserValue.toLowerCase();
     }
 
     private String getGroupName(final DirContextOperations ctx) {
@@ -753,7 +779,7 @@ public class LdapUserGroupProvider implements UserGroupProvider {
             }
         }
 
-        return referencedGroupValue;
+        return groupMembershipEnforceCaseSensitivity ? referencedGroupValue : referencedGroupValue.toLowerCase();
     }
 
     @AuthorizerContext

--- a/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/security/ldap/tenants/LdapUserGroupProviderTest.java
+++ b/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/security/ldap/tenants/LdapUserGroupProviderTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import static org.apache.nifi.registry.security.ldap.tenants.LdapUserGroupProvider.PROP_AUTHENTICATION_STRATEGY;
 import static org.apache.nifi.registry.security.ldap.tenants.LdapUserGroupProvider.PROP_CONNECT_TIMEOUT;
+import static org.apache.nifi.registry.security.ldap.tenants.LdapUserGroupProvider.PROP_GROUP_MEMBERSHIP_ENFORCE_CASE_SENSITIVITY;
 import static org.apache.nifi.registry.security.ldap.tenants.LdapUserGroupProvider.PROP_GROUP_MEMBER_ATTRIBUTE;
 import static org.apache.nifi.registry.security.ldap.tenants.LdapUserGroupProvider.PROP_GROUP_MEMBER_REFERENCED_USER_ATTRIBUTE;
 import static org.apache.nifi.registry.security.ldap.tenants.LdapUserGroupProvider.PROP_GROUP_NAME_ATTRIBUTE;
@@ -201,12 +202,22 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         ldapUserGroupProvider.onConfigured(configurationContext);
 
         assertEquals(8, ldapUserGroupProvider.getUsers().size());
-        assertEquals(2, ldapUserGroupProvider.getGroups().size());
+        assertEquals(3, ldapUserGroupProvider.getGroups().size());
 
-        final UserAndGroups userAndGroups = ldapUserGroupProvider.getUserAndGroups("user4");
-        assertNotNull(userAndGroups.getUser());
-        assertEquals(1, userAndGroups.getGroups().size());
-        assertEquals("cn=team1,ou=groups,o=nifi", userAndGroups.getGroups().iterator().next().getName());
+        final UserAndGroups user4AndGroups = ldapUserGroupProvider.getUserAndGroups("user4");
+        assertNotNull(user4AndGroups.getUser());
+        assertEquals(1, user4AndGroups.getGroups().size());
+        assertEquals("cn=team1,ou=groups,o=nifi", user4AndGroups.getGroups().iterator().next().getName());
+
+        final UserAndGroups user7AndGroups = ldapUserGroupProvider.getUserAndGroups("user7");
+        assertNotNull(user7AndGroups.getUser());
+        assertEquals(1, user7AndGroups.getGroups().size());
+        assertEquals("cn=team2,ou=groups,o=nifi", user7AndGroups.getGroups().iterator().next().getName());
+
+        final UserAndGroups user8AndGroups = ldapUserGroupProvider.getUserAndGroups("user8");
+        assertNotNull(user8AndGroups.getUser());
+        assertEquals(1, user8AndGroups.getGroups().size());
+        assertEquals("cn=Team2,ou=groups,o=nifi", user8AndGroups.getGroups().iterator().next().getName());
     }
 
     @Test
@@ -263,7 +274,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         ldapUserGroupProvider.onConfigured(configurationContext);
 
         final Set<Group> groups = ldapUserGroupProvider.getGroups();
-        assertEquals(4, groups.size());
+        assertEquals(5, groups.size());
         assertEquals(1, groups.stream().filter(group -> "cn=admins,ou=groups,o=nifi".equals(group.getName())).count());
     }
 
@@ -274,7 +285,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         when(configurationContext.getProperty(PROP_PAGE_SIZE)).thenReturn(new StandardPropertyValue("1"));
         ldapUserGroupProvider.onConfigured(configurationContext);
 
-        assertEquals(4, ldapUserGroupProvider.getGroups().size());
+        assertEquals(5, ldapUserGroupProvider.getGroups().size());
     }
 
     @Test
@@ -295,7 +306,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         when(configurationContext.getProperty(PROP_GROUP_SEARCH_SCOPE)).thenReturn(new StandardPropertyValue(SearchScope.SUBTREE.name()));
         ldapUserGroupProvider.onConfigured(configurationContext);
 
-        assertEquals(4, ldapUserGroupProvider.getGroups().size());
+        assertEquals(5, ldapUserGroupProvider.getGroups().size());
     }
 
     @Test
@@ -306,7 +317,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         ldapUserGroupProvider.onConfigured(configurationContext);
 
         final Set<Group> groups = ldapUserGroupProvider.getGroups();
-        assertEquals(4, groups.size());
+        assertEquals(5, groups.size());
 
         final Group admins = groups.stream().filter(group -> "admins".equals(group.getName())).findFirst().orElse(null);
         assertNotNull(admins);
@@ -324,7 +335,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         ldapUserGroupProvider.onConfigured(configurationContext);
 
         final Set<Group> groups = ldapUserGroupProvider.getGroups();
-        assertEquals(4, groups.size());
+        assertEquals(5, groups.size());
 
         final Group admins = groups.stream().filter(group -> "cn=admins,ou=groups,o=nifi".equals(group.getName())).findFirst().orElse(null);
         assertNotNull(admins);
@@ -343,7 +354,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         ldapUserGroupProvider.onConfigured(configurationContext);
 
         final Set<Group> groups = ldapUserGroupProvider.getGroups();
-        assertEquals(4, groups.size());
+        assertEquals(5, groups.size());
 
         final Group admins = groups.stream().filter(group -> "admins".equals(group.getName())).findFirst().orElse(null);
         assertNotNull(admins);
@@ -373,7 +384,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         assertEquals(8, ldapUserGroupProvider.getUsers().size());
 
         final Set<Group> groups = ldapUserGroupProvider.getGroups();
-        assertEquals(4, groups.size());
+        assertEquals(5, groups.size());
         groups.forEach(group -> assertTrue(group.getUsers().isEmpty()));
     }
 
@@ -388,7 +399,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         assertEquals(8, ldapUserGroupProvider.getUsers().size());
 
         final Set<Group> groups = ldapUserGroupProvider.getGroups();
-        assertEquals(4, groups.size());
+        assertEquals(5, groups.size());
 
         final Group team1 = groups.stream().filter(group -> "team1".equals(group.getName())).findFirst().orElse(null);
         assertNotNull(team1);
@@ -416,7 +427,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         assertEquals(8, ldapUserGroupProvider.getUsers().size());
 
         final Set<Group> groups = ldapUserGroupProvider.getGroups();
-        assertEquals(4, groups.size());
+        assertEquals(5, groups.size());
 
         final Group admins = groups.stream().filter(group -> "admins".equals(group.getName())).findFirst().orElse(null);
         assertNotNull(admins);
@@ -459,7 +470,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         assertEquals(8, ldapUserGroupProvider.getUsers().size());
 
         final Set<Group> groups = ldapUserGroupProvider.getGroups();
-        assertEquals(4, groups.size());
+        assertEquals(5, groups.size());
 
         final Group admins = groups.stream().filter(group -> "admins".equals(group.getName())).findFirst().orElse(null);
         assertNotNull(admins);
@@ -641,6 +652,81 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
                 user -> "User9".equals(user.getIdentity())).count());
     }
 
+    @Test
+    public void testSearchUsersAndGroupsMembershipThroughGroupsCaseInsensitive() throws Exception {
+        final AuthorizerConfigurationContext configurationContext = getBaseConfiguration(USER_SEARCH_BASE, GROUP_SEARCH_BASE);
+        when(configurationContext.getProperty(PROP_USER_IDENTITY_ATTRIBUTE)).thenReturn(new StandardPropertyValue("uid"));
+        when(configurationContext.getProperty(PROP_GROUP_MEMBER_ATTRIBUTE)).thenReturn(new StandardPropertyValue("member"));
+        when(configurationContext.getProperty(PROP_GROUP_NAME_ATTRIBUTE)).thenReturn(new StandardPropertyValue("cn"));
+        when(configurationContext.getProperty(PROP_GROUP_MEMBERSHIP_ENFORCE_CASE_SENSITIVITY)).thenReturn(new StandardPropertyValue("false"));
+        ldapUserGroupProvider.onConfigured(configurationContext);
+
+        assertEquals(8, ldapUserGroupProvider.getUsers().size());
+
+        final Set<Group> groups = ldapUserGroupProvider.getGroups();
+        assertEquals(5, groups.size());
+
+        final Group team4 = groups.stream().filter(group -> "team4".equals(group.getName())).findFirst().orElse(null);
+        assertNotNull(team4);
+        assertEquals(2, team4.getUsers().size());
+        assertEquals(1, team4.getUsers().stream().map(
+                userIdentifier -> ldapUserGroupProvider.getUser(userIdentifier)).filter(
+                user -> "user1".equals(user.getIdentity())).count());
+        assertEquals(1, team4.getUsers().stream().map(
+                userIdentifier -> ldapUserGroupProvider.getUser(userIdentifier)).filter(
+                user -> "user2".equals(user.getIdentity())).count());
+    }
+
+    @Test
+    public void testSearchUsersAndGroupsMembershipThroughGroupsCaseSensitive() throws Exception {
+        final AuthorizerConfigurationContext configurationContext = getBaseConfiguration(USER_SEARCH_BASE, GROUP_SEARCH_BASE);
+        when(configurationContext.getProperty(PROP_USER_IDENTITY_ATTRIBUTE)).thenReturn(new StandardPropertyValue("uid"));
+        when(configurationContext.getProperty(PROP_GROUP_MEMBER_ATTRIBUTE)).thenReturn(new StandardPropertyValue("member"));
+        when(configurationContext.getProperty(PROP_GROUP_NAME_ATTRIBUTE)).thenReturn(new StandardPropertyValue("cn"));
+        ldapUserGroupProvider.onConfigured(configurationContext);
+
+        assertEquals(8, ldapUserGroupProvider.getUsers().size());
+
+        final Set<Group> groups = ldapUserGroupProvider.getGroups();
+        assertEquals(5, groups.size());
+
+        final Group team4 = groups.stream().filter(group -> "team4".equals(group.getName())).findFirst().orElse(null);
+        assertNotNull(team4);
+        assertEquals(1, team4.getUsers().size());
+        assertEquals(1, team4.getUsers().stream().map(
+                userIdentifier -> ldapUserGroupProvider.getUser(userIdentifier)).filter(
+                user -> "user1".equals(user.getIdentity())).count());
+    }
+
+    @Test
+    public void testSearchUsersAndGroupsMembershipThroughUsersCaseInsensitive() throws Exception {
+        final AuthorizerConfigurationContext configurationContext = getBaseConfiguration(USER_SEARCH_BASE, GROUP_SEARCH_BASE);
+        when(configurationContext.getProperty(PROP_USER_IDENTITY_ATTRIBUTE)).thenReturn(new StandardPropertyValue("uid"));
+        when(configurationContext.getProperty(PROP_USER_GROUP_ATTRIBUTE)).thenReturn(new StandardPropertyValue("description")); // using description in lieu of memberof
+        when(configurationContext.getProperty(PROP_GROUP_NAME_ATTRIBUTE)).thenReturn(new StandardPropertyValue("cn"));
+        when(configurationContext.getProperty(PROP_GROUP_MEMBERSHIP_ENFORCE_CASE_SENSITIVITY)).thenReturn(new StandardPropertyValue("false"));
+        ldapUserGroupProvider.onConfigured(configurationContext);
+
+        assertEquals(8, ldapUserGroupProvider.getUsers().size());
+
+        final Set<Group> groups = ldapUserGroupProvider.getGroups();
+        assertEquals(5, groups.size());
+
+        final Group team1 = groups.stream().filter(group -> "team1".equals(group.getName())).findFirst().orElse(null);
+        assertNotNull(team1);
+        assertEquals(2, team1.getUsers().size());
+        assertEquals(2, team1.getUsers().stream().map(
+                userIdentifier -> ldapUserGroupProvider.getUser(userIdentifier)).filter(
+                user -> "user4".equals(user.getIdentity()) || "user5".equals(user.getIdentity())).count());
+
+        final Group team2 = groups.stream().filter(group -> "team2".equals(group.getName())).findFirst().orElse(null);
+        assertNotNull(team2);
+        assertEquals(3, team2.getUsers().size());
+        assertEquals(3, team2.getUsers().stream().map(
+                userIdentifier -> ldapUserGroupProvider.getUser(userIdentifier)).filter(
+                user -> "user6".equals(user.getIdentity()) || "user7".equals(user.getIdentity()) || "user8".equals(user.getIdentity())).count());
+    }
+
     private AuthorizerConfigurationContext getBaseConfiguration(final String userSearchBase, final String groupSearchBase) {
         final AuthorizerConfigurationContext configurationContext = mock(AuthorizerConfigurationContext.class);
         when(configurationContext.getProperty(PROP_URL)).thenReturn(new StandardPropertyValue("ldap://127.0.0.1:" + getLdapServer().getPort()));
@@ -649,6 +735,7 @@ public class LdapUserGroupProviderTest extends AbstractLdapTestUnit {
         when(configurationContext.getProperty(PROP_REFERRAL_STRATEGY)).thenReturn(new StandardPropertyValue(ReferralStrategy.FOLLOW.name()));
         when(configurationContext.getProperty(PROP_PAGE_SIZE)).thenReturn(new StandardPropertyValue(null));
         when(configurationContext.getProperty(PROP_SYNC_INTERVAL)).thenReturn(new StandardPropertyValue("30 mins"));
+        when(configurationContext.getProperty(PROP_GROUP_MEMBERSHIP_ENFORCE_CASE_SENSITIVITY)).thenReturn(new StandardPropertyValue("true"));
 
         when(configurationContext.getProperty(PROP_AUTHENTICATION_STRATEGY)).thenReturn(new StandardPropertyValue(LdapAuthenticationStrategy.SIMPLE.name()));
         when(configurationContext.getProperty(PROP_MANAGER_DN)).thenReturn(new StandardPropertyValue("uid=admin,ou=system"));

--- a/nifi-registry-core/nifi-registry-framework/src/test/resources/nifi-example.ldif
+++ b/nifi-registry-core/nifi-registry-framework/src/test/resources/nifi-example.ldif
@@ -110,6 +110,7 @@ objectClass: inetOrgPerson
 objectClass: top
 cn: User 8
 sn: User8
+description: cn=Team2,ou=groups,o=nifi
 uid: user8
 
 dn: cn=User 9,ou=users-2,o=nifi
@@ -156,6 +157,13 @@ objectClass: groupOfNames
 objectClass: top
 cn: team2
 member: cn=User 1,ou=users,o=nifi
+
+dn: cn=team4,ou=groups,o=nifi
+objectClass: groupOfNames
+objectClass: top
+cn: team4
+member: cn=User 1,ou=users,o=nifi
+member: cn=user 2,ou=users,o=nifi
 
 ## since the embedded ldap requires member to be fqdn, we are simulating using room and description
 

--- a/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/authorizers.xml
+++ b/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/authorizers.xml
@@ -82,6 +82,9 @@
         'Url' - Space-separated list of URLs of the LDAP servers (i.e. ldap://<hostname>:<port>).
         'Page Size' - Sets the page size when retrieving users and groups. If not specified, no paging is performed.
         'Sync Interval' - Duration of time between syncing users and groups. (i.e. 30 mins).
+        'Group Membership - Enforce Case Sensitivity' - Sets whether group membership decisions are case sensitive. When a user or group
+            is inferred (by not specifying or user or group search base or user identity attribute or group name attribute) case sensitivity
+            is enforced since the value to use for the user identity or group name would be ambiguous. Defaults to false.
 
         'User Search Base' - Base DN for searching for users (i.e. ou=users,o=nifi). Required to search users.
         'User Object Class' - Object class for identifying users (i.e. person). Required if searching users.
@@ -142,6 +145,7 @@
         <property name="Url"></property>
         <property name="Page Size"></property>
         <property name="Sync Interval">30 mins</property>
+        <property name="Group Membership - Enforce Case Sensitivity">false</property>
 
         <property name="User Search Base"></property>
         <property name="User Object Class">person</property>


### PR DESCRIPTION
NIFIREG-310:
- Introducing case insensitive group membership.
- Ensuring user identity and group name mapping is applied when the user identity or group name is inferred through group membership decisions.