### PR TITLE
NIFIREG-334 Support Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,49 @@
 
 language: java
 
-env:
-    - USER_LANGUAGE=en USER_REGION=US'
-    - USER_LANGUAGE=fr USER_REGION=FR'
-    - USER_LANGUAGE=ja USER_REGION=JP'
+matrix:
+  include:
+    - stage: "Build"
+      name: "Build Java 8 EN"
+      jdk: openjdk8
+      script: >-
+        mvn clean install -Pcontrib-check,jsUnitTests
+        -Dmaven.surefire.arguments="-Duser.language=en -Duser.region=US"
+        | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}
+    - stage: "Build"
+      name: "Build Java 8 FR"
+      jdk: openjdk8
+      script: >-
+        mvn clean install -Pcontrib-check,jsUnitTests
+        -Dmaven.surefire.arguments="-Duser.language=fr -Duser.region=FR"
+        | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}
+    - stage: "Build"
+      name: "Build Java 8 JP"
+      jdk: openjdk8
+      script: >-
+        mvn clean install -Pcontrib-check,jsUnitTests
+        -Dmaven.surefire.arguments="-Duser.language=ja -Duser.region=JP"
+        | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}
+  - stage: "Build"
+      name: "Build Java 11 EN"
+      # Do not specify "jdk:" here, install-jdk.sh will download the JDK set JAVA_HOME appropriately
+      before_script:
+        # Download the newest version of sormuras' install-jdk.sh to /tmp
+        # install-jdk.sh is used by Travis internally, sormoras is the maintainer of that script
+        - wget -O /tmp/install-jdk.sh https://github.com/sormuras/bach/raw/master/install-jdk.sh
+        # Need to specifically install AdoptOpenJDK 11.0.4 (Linux, HotSpot) since Travis does not offer it by default
+        # The link to the AdoptOpenJDK 11.0.4 .tar.gz is taken directly from AdoptOpenJDK's website
+        - >-
+          source /tmp/install-jdk.sh
+          --url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_linux_hotspot_11.0.4_11.tar.gz'
+      script:
+        - >-
+          mvn clean install -Pcontrib-check,jsUnitTests
+          -Dmaven.surefire.arguments="-Duser.language=en -Duser.region=US"
+          | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}
+
 
 os: linux
-
-jdk:
-    - openjdk8
 
 # Caches mvn repository in order to speed up builds
 cache:
@@ -55,7 +89,4 @@ before_script:
 # skip the installation step entirely
 install: true
 
-#build commands
-script:
-    - mvn clean install -Pcontrib-check,jsUnitTests | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,22 +23,25 @@ matrix:
       script: >-
         mvn clean install -Pcontrib-check,jsUnitTests
         -Dmaven.surefire.arguments="-Duser.language=en -Duser.region=US"
-        | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}
+        | grep -v -F -f .travis-output-filters
+        && exit ${PIPESTATUS[0]}
     - stage: "Build"
       name: "Build Java 8 FR"
       jdk: openjdk8
       script: >-
         mvn clean install -Pcontrib-check,jsUnitTests
         -Dmaven.surefire.arguments="-Duser.language=fr -Duser.region=FR"
-        | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}
+        | grep -v -F -f .travis-output-filters
+        && exit ${PIPESTATUS[0]}
     - stage: "Build"
       name: "Build Java 8 JP"
       jdk: openjdk8
       script: >-
         mvn clean install -Pcontrib-check,jsUnitTests
         -Dmaven.surefire.arguments="-Duser.language=ja -Duser.region=JP"
-        | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}
-  - stage: "Build"
+        | grep -v -F -f .travis-output-filters
+        && exit ${PIPESTATUS[0]}
+    - stage: "Build"
       name: "Build Java 11 EN"
       # Do not specify "jdk:" here, install-jdk.sh will download the JDK set JAVA_HOME appropriately
       before_script:
@@ -50,14 +53,14 @@ matrix:
         - >-
           source /tmp/install-jdk.sh
           --url 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x64_linux_hotspot_11.0.4_11.tar.gz'
-      script:
-        - >-
-          mvn clean install -Pcontrib-check,jsUnitTests
-          -Dmaven.surefire.arguments="-Duser.language=en -Duser.region=US"
-          | grep -v -F -f .travis-output-filters && exit ${PIPESTATUS[0]}
+      script: >-
+        mvn clean install -Pcontrib-check,jsUnitTests
+        -Dmaven.surefire.arguments="-Duser.language=en -Duser.region=US"
+        | grep -v -F -f .travis-output-filters
+        && exit ${PIPESTATUS[0]}
 
-
-os: linux
+os:
+    - linux
 
 # Caches mvn repository in order to speed up builds
 cache:

--- a/nifi-registry-assembly/LICENSE
+++ b/nifi-registry-assembly/LICENSE
@@ -1346,3 +1346,269 @@ For details see https://www.eclipse.org/org/documents/edl-v10.php
     STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
     ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
     ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This product bundles 'Jakarta jaxb-api' which is available under a Eclipse Distribution License - v 1.0 license.
+For details see https://www.eclipse.org/org/documents/edl-v10.php
+
+    Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, are permitted provided that the following
+    conditions are met:
+
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    - Neither the name of the Eclipse Foundation, Inc. nor the
+      names of its contributors may be used to endorse or promote
+      products derived from this software without specific prior
+      written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This product bundles 'Jakarta jaxb-ri' which is available under a Eclipse Distribution License - v 1.0 license.
+For details see https://www.eclipse.org/org/documents/edl-v10.php
+
+    Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, are permitted provided that the following
+    conditions are met:
+
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    - Neither the name of the Eclipse Foundation, Inc. nor the
+      names of its contributors may be used to endorse or promote
+      products derived from this software without specific prior
+      written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This product bundles 'Jakarta jaxb-fi' which is available under a Eclipse Distribution License - v 1.0 license.
+For details see https://www.eclipse.org/org/documents/edl-v10.php
+
+    Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, are permitted provided that the following
+    conditions are met:
+
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    - Neither the name of the Eclipse Foundation, Inc. nor the
+      names of its contributors may be used to endorse or promote
+      products derived from this software without specific prior
+      written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This product bundles 'Jakarta jaxb-istack-commons' which is available under a Eclipse Distribution License - v 1.0 license.
+For details see https://www.eclipse.org/org/documents/edl-v10.php
+
+    Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, are permitted provided that the following
+    conditions are met:
+
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    - Neither the name of the Eclipse Foundation, Inc. nor the
+      names of its contributors may be used to endorse or promote
+      products derived from this software without specific prior
+      written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This product bundles 'Jakarta jaxb-stax-ex' which is available under a Eclipse Distribution License - v 1.0 license.
+For details see https://www.eclipse.org/org/documents/edl-v10.php
+
+    Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, are permitted provided that the following
+    conditions are met:
+
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    - Neither the name of the Eclipse Foundation, Inc. nor the
+      names of its contributors may be used to endorse or promote
+      products derived from this software without specific prior
+      written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This product bundles 'Jakarta txw2 runtime' which is available under a Eclipse Distribution License - v 1.0 license.
+For details see https://www.eclipse.org/org/documents/edl-v10.php
+
+    Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, are permitted provided that the following
+    conditions are met:
+
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    - Neither the name of the Eclipse Foundation, Inc. nor the
+      names of its contributors may be used to endorse or promote
+      products derived from this software without specific prior
+      written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This product bundles 'Jakarta Activation' which is available under a Eclipse Distribution License - v 1.0 license.
+For details see https://www.eclipse.org/org/documents/edl-v10.php
+
+    Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, are permitted provided that the following
+    conditions are met:
+
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    - Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    - Neither the name of the Eclipse Foundation, Inc. nor the
+      names of its contributors may be used to endorse or promote
+      products derived from this software without specific prior
+      written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+    CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/nifi-registry-assembly/pom.xml
+++ b/nifi-registry-assembly/pom.xml
@@ -131,6 +131,16 @@
             <scope>runtime</scope>
             <type>zip</type>
         </dependency>
+        <!-- Dependencies required for running on Java 11 that will be placed in the lib/java11 dir -->
+        <!-- TODO: remove these once minimum Java version is 11 and these can be bundle directly into the application -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/nifi-registry-assembly/src/main/assembly/dependencies.xml
+++ b/nifi-registry-assembly/src/main/assembly/dependencies.xml
@@ -53,6 +53,21 @@
             </includes>
         </dependencySet>
 
+        <!-- Write out the libs for java11 to its own dir -->
+        <!-- TODO: remove these once minimum Java version is 11 and these can be bundle directly into the application -->
+        <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>lib/java11</outputDirectory>
+            <directoryMode>0770</directoryMode>
+            <fileMode>0664</fileMode>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
+                <include>org.glassfish.jaxb:jaxb-runtime</include>
+            </includes>
+        </dependencySet>
+
         <!-- Write out all dependency artifacts to lib directory -->
         <dependencySet>
             <scope>runtime</scope>
@@ -68,6 +83,11 @@
                 <exclude>nifi-registry-docs</exclude>
                 <exclude>nifi-registry-ranger-assembly</exclude>
                 <exclude>nifi-registry-aws-assembly</exclude>
+
+                <!-- Exclude any jaxb dependencies because they will be in lib/java11 -->
+                <!-- TODO: remove these once minimum Java version is 11 and these can be bundle directly into the application -->
+                <exclude>jakarta.xml.bind:jakarta.xml.bind-api</exclude>
+                <exclude>org.glassfish.jaxb:jaxb-runtime</exclude>
             </excludes>
         </dependencySet>
         

--- a/nifi-registry-core/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/RunNiFiRegistry.java
+++ b/nifi-registry-core/nifi-registry-bootstrap/src/main/java/org/apache/nifi/registry/bootstrap/RunNiFiRegistry.java
@@ -48,6 +48,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -920,6 +921,20 @@ public class RunNiFiRegistry {
             cpFiles.add(file.getAbsolutePath());
         }
 
+        final String runtimeJavaVersion = System.getProperty("java.version");
+        defaultLogger.info("Runtime Java version: {}", runtimeJavaVersion);
+        if (Integer.parseInt(runtimeJavaVersion.substring(0, runtimeJavaVersion.indexOf('.'))) >= 11) {
+            // If running on Java 11 or greater, add lib/java11 to the classpath.
+            // TODO: Once the minimum Java version requirement of NiFi Registry is 11, this processing should be removed.
+            final String libJava11Filename = replaceNull(props.get("lib.dir"), "./lib").trim() + "/java11";
+            final File libJava11Dir = getFile(libJava11Filename, workingDir);
+            if (libJava11Dir.exists()) {
+                for (final File file : Objects.requireNonNull(libJava11Dir.listFiles((dir, filename) -> filename.toLowerCase().endsWith(".jar")))) {
+                    cpFiles.add(file.getAbsolutePath());
+                }
+            }
+        }
+
         final StringBuilder classPathBuilder = new StringBuilder();
         for (int i = 0; i < cpFiles.size(); i++) {
             final String filename = cpFiles.get(i);
@@ -961,6 +976,13 @@ public class RunNiFiRegistry {
         cmd.add("-Dnifi.registry.bootstrap.config.docs.dir=" + nifiRegistryDocsDir);
         cmd.add("-Dapp=NiFiRegistry");
         cmd.add("-Dorg.apache.nifi.registry.bootstrap.config.log.dir=" + nifiRegistryLogDir);
+
+        if (runtimeJavaVersion.startsWith("9") || runtimeJavaVersion.startsWith("10")) {
+            // running on Java 9+, java.xml.bind module must be made available
+            // running on Java 9 or 10, internal module java.xml.bind module must be made available
+            cmd.add("--add-modules=java.xml.bind");
+        }
+
         cmd.add("org.apache.nifi.registry.NiFiRegistry");
 
         builder.command(cmd);

--- a/nifi-registry-core/nifi-registry-bundle-utils/pom.xml
+++ b/nifi-registry-core/nifi-registry-bundle-utils/pom.xml
@@ -33,4 +33,20 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <!-- This profile provides configuration to allow NiFi Registry to be compiled on JDKs above 1.8. -->
+            <id>jigsaw</id>
+            <activation>
+                <jdk>(1.8,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
 </project>

--- a/nifi-registry-core/nifi-registry-data-model/pom.xml
+++ b/nifi-registry-core/nifi-registry-data-model/pom.xml
@@ -34,4 +34,20 @@
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <!-- This profile provides configuration to allow NiFi Registry to be compiled on JDKs above 1.8. -->
+            <id>jigsaw</id>
+            <activation>
+                <jdk>(1.8,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -370,13 +370,11 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.12</version>
+            <artifactId>groovy-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-registry-core/nifi-registry-framework/pom.xml
+++ b/nifi-registry-core/nifi-registry-framework/pom.xml
@@ -138,15 +138,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
@@ -279,6 +270,11 @@
                     <groupId>org.hibernate</groupId>
                     <artifactId>hibernate-core</artifactId>
                 </exclusion>
+                <!-- JDK 8 will already have jaxb-api, and JDKs above 8 we activate a profile to include it -->
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -388,11 +384,31 @@
             <artifactId>apacheds-all</artifactId>
             <version>2.0.0-M24</version>
             <scope>test</scope>
-	</dependency>
-	<dependency>
+	    </dependency>
+	    <dependency>
             <groupId>org.apache.nifi.registry</groupId>
             <artifactId>nifi-registry-flow-diff</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
-    </dependencies>
+        </dependencies>
+
+    <profiles>
+        <profile>
+            <!-- This profile provides configuration to allow NiFi Registry to be compiled on JDKs above 1.8. -->
+            <id>jigsaw</id>
+            <activation>
+                <jdk>(1.8,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/nifi-registry-core/nifi-registry-properties/pom.xml
+++ b/nifi-registry-core/nifi-registry-properties/pom.xml
@@ -53,8 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.12</version>
+            <artifactId>groovy-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-registry-core/nifi-registry-properties/src/test/groovy/org/apache/nifi/registry/properties/AESSensitivePropertyProviderTest.groovy
+++ b/nifi-registry-core/nifi-registry-properties/src/test/groovy/org/apache/nifi/registry/properties/AESSensitivePropertyProviderTest.groovy
@@ -17,7 +17,6 @@
 package org.apache.nifi.registry.properties
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.bouncycastle.util.encoders.DecoderException
 import org.bouncycastle.util.encoders.Hex
 import org.junit.*
 import org.junit.runner.RunWith
@@ -83,7 +82,7 @@ class AESSensitivePropertyProviderTest extends GroovyTestCase {
                 if (Cipher.getMaxAllowedKeyLength("AES") < keySize) {
                     throw new IllegalArgumentException("The JCE unlimited strength cryptographic jurisdiction policies are not installed, so the max key size is 128 bits")
                 }
-                return KEY_256_HEX[0..<(keySize / 4)]
+                return KEY_256_HEX[0..<keySize.intdiv(4)]
             default:
                 throw new IllegalArgumentException("Key size ${keySize} bits is not valid")
         }

--- a/nifi-registry-core/nifi-registry-security-utils/pom.xml
+++ b/nifi-registry-core/nifi-registry-security-utils/pom.xml
@@ -40,7 +40,11 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nifi-registry-core/nifi-registry-web-api/pom.xml
+++ b/nifi-registry-core/nifi-registry-web-api/pom.xml
@@ -424,13 +424,11 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.12</version>
+            <artifactId>groovy-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-registry-core/nifi-registry-web-api/pom.xml
+++ b/nifi-registry-core/nifi-registry-web-api/pom.xml
@@ -282,6 +282,28 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- This profile provides configuration to allow NiFi Registry to be compiled on JDKs above 1.8. -->
+            <id>jigsaw</id>
+            <activation>
+                <jdk>(1.8,)</jdk>
+            </activation>
+            <!-- These dependencies would normally be transitive deps of framework and data model, but we want to
+                redeclare them with provided scope so that they don't end up in WEB-INF/lib of the WAR, they will
+                be added to the lib/java11 directory and added to the classpath based on the JVM being used -->
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -299,6 +321,11 @@
                 <exclusion>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-aop</artifactId>
+                </exclusion>
+                <!-- JDK 8 will already have jaxb-api, and JDKs above 8 we activate a profile to include it -->
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/nifi-registry-core/pom.xml
+++ b/nifi-registry-core/pom.xml
@@ -47,7 +47,7 @@
         <module>nifi-registry-docker</module>
         <module>nifi-registry-bundle-utils</module>
         <module>nifi-registry-test</module>
-	<module>nifi-registry-revision</module>
+	    <module>nifi-registry-revision</module>
     </modules>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,8 @@
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <testcontainers.version>1.11.2</testcontainers.version>
 	    <h2.version>1.4.197</h2.version>
+        <groovy.version>2.5.4</groovy.version>
+        <groovy.eclipse.compiler.version>3.4.0-01</groovy.eclipse.compiler.version>
     </properties>
 
     <repositories>
@@ -151,8 +153,18 @@
                 <enabled>false</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>bintray</id>
+            <name>Groovy Bintray</name>
+            <url>https://dl.bintray.com/groovy/maven</url>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
-
 
     <dependencyManagement>
         <dependencies>
@@ -249,7 +261,38 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.7.22</version>
+                <version>2.28.2</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- force mockito-core to a newer version -->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>1.9.10</version>
+            </dependency>
+            <!-- force mockito-core to a newer version -->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>1.9.10</version>
+            </dependency>
+            <!-- exclude all transitive groovy deps so that spock uses whatever is directly declared -->
+            <dependency>
+                <groupId>org.spockframework</groupId>
+                <artifactId>spock-core</artifactId>
+                <version>1.3-groovy-2.5</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-test</artifactId>
+                <version>${groovy.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -275,7 +318,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <fork>true</fork>
                         <optimize>true</optimize>
@@ -286,7 +329,7 @@
                 <plugin>
                     <groupId>org.codehaus.groovy</groupId>
                     <artifactId>groovy-eclipse-compiler</artifactId>
-                    <version>2.9.2-01</version>
+                    <version>${groovy.eclipse.compiler.version}</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>
@@ -457,12 +500,12 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-compiler</artifactId>
-                        <version>2.9.2-01</version>
+                        <version>${groovy.eclipse.compiler.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-batch</artifactId>
-                        <version>2.4.3-01</version>
+                        <version>${groovy.version}-01</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
 	    <h2.version>1.4.197</h2.version>
         <groovy.version>2.5.4</groovy.version>
         <groovy.eclipse.compiler.version>3.4.0-01</groovy.eclipse.compiler.version>
+        <jaxb.version>2.3.2</jaxb.version>
     </properties>
 
     <repositories>
@@ -210,6 +211,17 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.5</version>
+            </dependency>
+        <!-- lib/java11 -->
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb.version}</version>
             </dependency>
 	    <!-- NiFi Registry Modules -->
             <dependency>
@@ -390,7 +402,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jaxb2-maven-plugin</artifactId>
-                    <version>2.3.1</version>
+                    <version>2.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -493,8 +505,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -762,6 +774,17 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <profile>
+            <!-- This profile provides configuration to allow NiFi Registry to be compiled on JDKs above 1.8. -->
+            <id>jigsaw</id>
+            <activation>
+                <jdk>(1.8,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
This build introduces similar changes that were made in NiFi to support the following scenarios..
- Build on Java 8, run on Java 8
- Build on Java 8, run on Java 11
- Build on Java 11, run on Java 11

The primary changes include upgrading Groovy to a Java 11 compatible version, and creating profiles to optionally include JAX-B dependencies when building/running on JDKs above 8.