### PR TITLE
NIFIREG-227 GitFlowPersistenceProvider option to clone repo on startup

### DIFF
--- a/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -1315,11 +1315,14 @@ Qualified class name: `org.apache.nifi.registry.provider.flow.git.GitFlowPersist
 link:https://git-scm.com/book/en/v2/Git-Internals-The-Refspec[https://git-scm.com/book/en/v2/Git-Internals-The-Refspec^]).
 |`Remote Access User`|This username is used to make push requests to the remote repository when `Remote To Push` is enabled, and the remote repository is accessed by HTTP protocol. If SSH is used, user authentication is done with SSH keys.
 |`Remote Access Password`|The password for the `Remote Access User`.
+|`Remote Clone Repository`|Remote repository URI to clone into `Flow Storage Directory` if local repository is not present in `Flow Storage Directory`. If left empty then you will have to configure git directory as per <<Initialize Git directory>> but if remote URI is provided then correct `Remote Access User` and `Remote Access Password` also should be present.
+Currently, default branch of remote will be cloned.
 |====
 
 ===== Initialize Git directory
 
-In order to use `GitFlowPersistenceRepository`, you need to prepare a Git directory on the local file system. You can do so by initializing a directory with `git init` command, or clone an existing Git project from a remote Git repository by `git clone` command.
+In order to use `GitFlowPersistenceRepository`, you need to prepare a Git directory on the local file system. You can do so by initializing a directory with `git init` command, or clone an existing Git project from a remote Git repository by `git clone` command. If you want to clone the default branch of remote then you can set `Remote Clone Repository`
+as described above.
 
 - `git init` command
 link:https://git-scm.com/docs/git-init[https://git-scm.com/docs/git-init^]

--- a/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -1315,14 +1315,13 @@ Qualified class name: `org.apache.nifi.registry.provider.flow.git.GitFlowPersist
 link:https://git-scm.com/book/en/v2/Git-Internals-The-Refspec[https://git-scm.com/book/en/v2/Git-Internals-The-Refspec^]).
 |`Remote Access User`|This username is used to make push requests to the remote repository when `Remote To Push` is enabled, and the remote repository is accessed by HTTP protocol. If SSH is used, user authentication is done with SSH keys.
 |`Remote Access Password`|The password for the `Remote Access User`.
-|`Remote Clone Repository`|Remote repository URI to clone into `Flow Storage Directory` if local repository is not present in `Flow Storage Directory`. If left empty then you will have to configure git directory as per <<Initialize Git directory>> but if remote URI is provided then correct `Remote Access User` and `Remote Access Password` also should be present.
+|`Remote Clone Repository`|Remote repository URI to use to clone into `Flow Storage Directory`, if local repository is not present in `Flow Storage Directory`. If left empty the git directory needs to be configured as per <<Initialize Git directory>>. If URI is provided then `Remote Access User` and `Remote Access Password` also should be present.
 Currently, default branch of remote will be cloned.
 |====
 
 ===== Initialize Git directory
 
-In order to use `GitFlowPersistenceRepository`, you need to prepare a Git directory on the local file system. You can do so by initializing a directory with `git init` command, or clone an existing Git project from a remote Git repository by `git clone` command. If you want to clone the default branch of remote then you can set `Remote Clone Repository`
-as described above.
+In order to use `GitFlowPersistenceRepository`, you need to prepare a Git directory on the local file system. You can do so by initializing a directory with `git init` command, or clone an existing Git project from a remote Git repository by `git clone` command. If you want to clone the default branch of remote repository automatically, set the `Remote Clone Repository` as described above.
 
 - `git init` command
 link:https://git-scm.com/docs/git-init[https://git-scm.com/docs/git-init^]

--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
@@ -147,10 +147,11 @@ class GitFlowMetaData {
     }
 
     /**
-     * Check if provided local repository exists or not at given 'Flow Storage Directory' in providers.xml
-     * @param localRepo file object of 'Flow Storage Directory'
-     * @return true if local repository exists else false
-     * @throws IOException if .git of local repository cannot be opened
+     * Check if the provided local repository exists or not, provided by the 'Flow Storage Directory'
+     * configuration in the providers.xml.
+     * @param localRepo  {@link File} object of the 'Flow Storage Directory' configuration
+     * @return true if the local repository exists, false otherwise
+     * @throws IOException if the .git directory of the local repository cannot be opened
      */
     public boolean localRepoExists(File localRepo) throws IOException {
         if (!localRepo.isDirectory()) {
@@ -173,10 +174,10 @@ class GitFlowMetaData {
     }
 
     /**
-     * Validate if provided 'Remote Clone Repository' in providers.xml exists or not. If remote repository
-     * doesn't exist then will throw IllegalArgumentException
-     * @param remoteRepository URI value of 'Remote Clone Repository'
-     * @throws IOException if unable to create repository
+     * Validate if the provided 'Remote Clone Repository' configuration in the providers.xml exists or not.
+     * If the remote repository does not exist, an {@link IllegalArgumentException} will be thrown.
+     * @param remoteRepository the URI value of the 'Remote Clone Repository' configuration
+     * @throws IOException if creating the repository fails
      */
     public void remoteRepoExists(String remoteRepository) throws IOException {
         final Git git = new Git(FileRepositoryBuilder.create(new File(remoteRepository)));
@@ -191,10 +192,10 @@ class GitFlowMetaData {
     }
 
     /**
-     * If validation of remote clone repository throws no exception then clone the given 'Remote Clone Repository' in
-     * provided 'Flow Storage Directory'. Currently the default branch of remote will be cloned.
-     * @param localRepo file object of 'Flow Storage Directory'
-     * @param remoteRepository URI value of 'Remote Clone Repository'
+     * If validation of remote clone repository throws no exception then clone the repository given
+     * in the 'Remote Clone Repository' configuration. Currently the default branch of remote will be cloned.
+     * @param localRepo {@link File} object of the 'Flow Storage Directory' configuration
+     * @param remoteRepository the URI value of the 'Remote Clone Repository' configuration
      * @throws GitAPIException if unable to call the remote repository
      */
     public void cloneRepository(File localRepo, String remoteRepository) throws GitAPIException {

--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
@@ -18,12 +18,15 @@ package org.apache.nifi.registry.provider.flow.git;
 
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.LsRemoteCommand;
 import org.eclipse.jgit.api.PushCommand;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoHeadException;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.RepositoryCache;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
@@ -32,6 +35,7 @@ import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.util.FS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -129,6 +133,57 @@ class GitFlowMetaData {
         }
 
         return builder.build();
+    }
+
+    private static boolean hasAtLeastOneReference(Repository repo) {
+        logger.info(repo.toString());
+        for (Ref ref : repo.getAllRefs().values()) {
+            if (ref.getObjectId() == null)
+                continue;
+            return true;
+        }
+        return false;
+    }
+
+    public boolean localRepoExists(File localRepo) throws IOException {
+        if (!localRepo.isDirectory()) {
+            logger.info("{} is not a directory or does not exist.", localRepo.getPath());
+            return false;
+        }
+
+        if (RepositoryCache.FileKey.isGitRepository(new File(localRepo.getPath()+"/.git"), FS.DETECTED)) {
+            Git git = Git.open(new File(localRepo.getPath() + "/.git"));
+            Repository repository = git.getRepository();
+            logger.info("Checking for git references in {}", localRepo.getPath());
+            boolean referenceExists = hasAtLeastOneReference(repository);
+            if (referenceExists)
+                logger.info("{} local repository exists with references so no need to clone remote", localRepo.getPath());
+            // Can be an empty repository if no references are present should we pull from remote?
+            return true;
+        }
+        return false;
+    }
+
+    public void remoteRepoExists(String remoteRepository) throws IOException {
+        Git git = new Git(FileRepositoryBuilder.create(new File(remoteRepository)));
+        final LsRemoteCommand lsCmd = git.lsRemote();
+        try {
+            lsCmd.setRemote(remoteRepository);
+            lsCmd.setCredentialsProvider(this.credentialsProvider);
+            lsCmd.call();
+        }
+        catch (Exception e){
+            throw new IllegalArgumentException("InvalidRemoteRepository : Given remote repository is not valid");
+        }
+    }
+
+    public void cloneRepository (File localRepo, String remoteRepository) throws GitAPIException {
+        logger.info("Cloning the repository {} in {}", remoteRepository, localRepo.getPath());
+        Git.cloneRepository()
+                .setURI(remoteRepository)
+                .setCredentialsProvider(this.credentialsProvider)
+                .setDirectory(new File(localRepo.getPath()))
+                .call();
     }
 
     @SuppressWarnings("unchecked")

--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
@@ -171,13 +171,12 @@ class GitFlowMetaData {
             lsCmd.setRemote(remoteRepository);
             lsCmd.setCredentialsProvider(this.credentialsProvider);
             lsCmd.call();
-        }
-        catch (Exception e){
+        } catch (Exception e){
             throw new IllegalArgumentException("InvalidRemoteRepository : Given remote repository is not valid");
         }
     }
 
-    public void cloneRepository (File localRepo, String remoteRepository) throws GitAPIException {
+    public void cloneRepository(File localRepo, String remoteRepository) throws GitAPIException {
         logger.info("Cloning the repository {} in {}", remoteRepository, localRepo.getPath());
         Git.cloneRepository()
                 .setURI(remoteRepository)

--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowMetaData.java
@@ -182,7 +182,7 @@ class GitFlowMetaData {
         Git.cloneRepository()
                 .setURI(remoteRepository)
                 .setCredentialsProvider(this.credentialsProvider)
-                .setDirectory(new File(localRepo.getPath()))
+                .setDirectory(localRepo)
                 .call();
     }
 

--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/provider/flow/git/GitFlowPersistenceProvider.java
@@ -76,9 +76,10 @@ public class GitFlowPersistenceProvider implements MetadataAwareFlowPersistenceP
         final String remotePassword = props.get(REMOTE_ACCESS_PASSWORD);
         final String remoteRepo = props.get(REMOTE_CLONE_REPOSITORY);
         if (!isEmpty(remoteRepo)) {
-            if (isEmpty(remoteUser) || isEmpty(remotePassword))
+            if (isEmpty(remoteUser) || isEmpty(remotePassword)) {
                 throw new ProviderCreationException(format("The property %s needs remote username and remote password",
                         REMOTE_CLONE_REPOSITORY));
+            }
         }
         if (!isEmpty(remoteUser) && isEmpty(remotePassword)) {
             throw new ProviderCreationException(format("The property %s is specified but %s is not." +
@@ -91,7 +92,7 @@ public class GitFlowPersistenceProvider implements MetadataAwareFlowPersistenceP
 
         try {
             flowStorageDir = new File(flowStorageDirValue);
-            boolean localRepoExists = flowMetaData.localRepoExists(flowStorageDir);
+            final boolean localRepoExists = flowMetaData.localRepoExists(flowStorageDir);
             if (remoteRepo != null && !remoteRepo.isEmpty() && !localRepoExists){
                 flowMetaData.remoteRepoExists(remoteRepo);
                 flowMetaData.cloneRepository(flowStorageDir, remoteRepo);

--- a/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/providers.xml
+++ b/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/providers.xml
@@ -33,6 +33,7 @@
         <property name="Remote To Push"></property>
         <property name="Remote Access User"></property>
         <property name="Remote Access Password"></property>
+        <property name="Remote Clone Repository"></property>
     </flowPersistenceProvider>
     -->
 


### PR DESCRIPTION
As per NIFIREG-227 I have added a property REMOTE_CLONE_REPOSITORY which if set will clone from the given repository but at the same time if this value is set then users will need to provide both user name and password. Then we check if flowstoragedir is our local repository or not and if not then we check if given remote repo is actually valid and if everything is ok then we clone remote to flowstoragedir then proceed forward. 

Please do give your suggestions and recommendations so that changes made further will be good.