### PR TITLE
NIFIREG-356 Fixing additional classpath resources for Authorizers and…

### DIFF
--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionClassLoader.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionClassLoader.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.extension;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Extend URLClassLoader to keep track of the root directory.
+ */
+public class ExtensionClassLoader extends URLClassLoader {
+
+    private final String rootDir;
+
+    public ExtensionClassLoader(final String rootDir, final URL[] urls, final ClassLoader parent) {
+        super(urls, parent);
+        this.rootDir = rootDir;
+    }
+
+    public String getRootDir() {
+        return rootDir;
+    }
+}

--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionCloseable.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionCloseable.java
@@ -40,6 +40,13 @@ public class ExtensionCloseable implements Closeable {
         return closeable;
     }
 
+    public static ExtensionCloseable withClassLoader(final ClassLoader componentClassLoader) {
+        final ClassLoader current = Thread.currentThread().getContextClassLoader();
+        final ExtensionCloseable closeable = new ExtensionCloseable(current);
+        Thread.currentThread().setContextClassLoader(componentClassLoader);
+        return closeable;
+    }
+
     @Override
     public void close() throws IOException {
         if (toSet != null) {

--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionManager.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/extension/ExtensionManager.java
@@ -33,7 +33,6 @@ import javax.annotation.PostConstruct;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,7 +87,7 @@ public class ExtensionManager {
         }
     }
 
-    public ClassLoader getExtensionClassLoader(final String canonicalClassName) {
+    public ExtensionClassLoader getExtensionClassLoader(final String canonicalClassName) {
         if (StringUtils.isBlank(canonicalClassName)) {
             throw new IllegalArgumentException("Class name can not be null");
         }
@@ -199,20 +198,4 @@ public class ExtensionManager {
         return new ExtensionClassLoader(dir, urls, parentClassLoader);
     }
 
-    /**
-     * Extend URLClassLoader to keep track of the root directory.
-     */
-    private static class ExtensionClassLoader extends URLClassLoader {
-
-        private final String rootDir;
-
-        public ExtensionClassLoader(final String rootDir, final URL[] urls, final ClassLoader parent) {
-            super(urls, parent);
-            this.rootDir = rootDir;
-        }
-
-        public String getRootDir() {
-            return rootDir;
-        }
-    }
 }

--- a/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/util/ClassLoaderUtils.java
+++ b/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/util/ClassLoaderUtils.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.security.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+public class ClassLoaderUtils {
+
+    static final Logger LOGGER = LoggerFactory.getLogger(ClassLoaderUtils.class);
+
+    public static ClassLoader getCustomClassLoader(String modulePath, ClassLoader parentClassLoader, FilenameFilter filenameFilter) throws MalformedURLException {
+        URL[] classpaths = getURLsForClasspath(modulePath, filenameFilter, false);
+        return createModuleClassLoader(classpaths, parentClassLoader);
+    }
+
+    /**
+     *
+     * @param modulePath a module path to get URLs from, the module path may be
+     * a comma-separated list of paths
+     * @param filenameFilter a filter to apply when a module path is a directory
+     * and performs a listing, a null filter will return all matches
+     * @param suppressExceptions indicates whether to suppress exceptions
+     * @return an array of URL instances representing all of the modules
+     * resolved from processing modulePath
+     * @throws MalformedURLException if a module path does not exist
+     */
+    public static URL[] getURLsForClasspath(String modulePath, FilenameFilter filenameFilter, boolean suppressExceptions) throws MalformedURLException {
+        return getURLsForClasspath(modulePath == null ? Collections.emptySet() : Collections.singleton(modulePath), filenameFilter, suppressExceptions);
+    }
+
+    /**
+     *
+     * @param modulePaths one or modules paths to get URLs from, each module
+     * path may be a comma-separated list of paths
+     * @param filenameFilter a filter to apply when a module path is a directory
+     * and performs a listing, a null filter will return all matches
+     * @param suppressExceptions if true then all modules will attempt to be
+     * resolved even if some throw an exception, if false the first exception
+     * will be thrown
+     * @return an array of URL instances representing all of the modules
+     * resolved from processing modulePaths
+     * @throws MalformedURLException if a module path does not exist
+     */
+    public static URL[] getURLsForClasspath(Set<String> modulePaths, FilenameFilter filenameFilter, boolean suppressExceptions) throws MalformedURLException {
+        // use LinkedHashSet to maintain the ordering that the incoming paths are processed
+        Set<String> modules = new LinkedHashSet<>();
+        if (modulePaths != null) {
+            modulePaths.stream()
+                    .flatMap(path -> Arrays.stream(path.split(",")))
+                    .filter(path -> isNotBlank(path))
+                    .map(String::trim)
+                    .forEach(m -> modules.add(m));
+        }
+        return toURLs(modules, filenameFilter, suppressExceptions);
+    }
+
+    private static boolean isNotBlank(final String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    protected static URL[] toURLs(Set<String> modulePaths, FilenameFilter filenameFilter, boolean suppressExceptions) throws MalformedURLException {
+        List<URL> additionalClasspath = new LinkedList<>();
+        if (modulePaths != null) {
+            for (String modulePathString : modulePaths) {
+                // If the path is already a URL, just add it (but don't check if it exists, too expensive and subject to network availability)
+                boolean isUrl = true;
+                try {
+                    additionalClasspath.add(new URL(modulePathString));
+                } catch (MalformedURLException mue) {
+                    isUrl = false;
+                }
+                if (!isUrl) {
+                    try {
+                        File modulePath = new File(modulePathString);
+
+                        if (modulePath.exists()) {
+
+                            additionalClasspath.add(modulePath.toURI().toURL());
+
+                            if (modulePath.isDirectory()) {
+                                File[] files = modulePath.listFiles(filenameFilter);
+
+                                if (files != null) {
+                                    for (File classpathResource : files) {
+                                        if (classpathResource.isDirectory()) {
+                                            LOGGER.warn("Recursive directories are not supported, skipping " + classpathResource.getAbsolutePath());
+                                        } else {
+                                            additionalClasspath.add(classpathResource.toURI().toURL());
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            throw new MalformedURLException("Path specified does not exist");
+                        }
+                    } catch (MalformedURLException e) {
+                        if (!suppressExceptions) {
+                            throw e;
+                        }
+                    }
+                }
+            }
+        }
+        return additionalClasspath.toArray(new URL[additionalClasspath.size()]);
+    }
+
+    protected static ClassLoader createModuleClassLoader(URL[] modules, ClassLoader parentClassLoader) {
+        return new URLClassLoader(modules, parentClassLoader);
+    }
+
+}

--- a/nifi-registry-core/nifi-registry-framework/src/test/groovy/org/apache/nifi/registry/security/authorization/AuthorizerFactorySpec.groovy
+++ b/nifi-registry-core/nifi-registry-framework/src/test/groovy/org/apache/nifi/registry/security/authorization/AuthorizerFactorySpec.groovy
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.registry.security.authorization
 
+import org.apache.nifi.registry.extension.ExtensionClassLoader
 import org.apache.nifi.registry.extension.ExtensionManager
 import org.apache.nifi.registry.properties.NiFiRegistryProperties
 import org.apache.nifi.registry.security.authorization.resource.ResourceFactory
@@ -32,7 +33,7 @@ class AuthorizerFactorySpec extends Specification {
 
     // runs before every feature method
     def setup() {
-        mockExtensionManager.getExtensionClassLoader(_) >> this.getClass().getClassLoader()
+        mockExtensionManager.getExtensionClassLoader(_) >> new ExtensionClassLoader("/tmp", new URL[0],this.getClass().getClassLoader())
         mockProperties.getPropertyKeys() >> new HashSet<String>() // Called by IdentityMappingUtil.getIdentityMappings()
 
         authorizerFactory = new AuthorizerFactory(mockProperties, mockExtensionManager, null, mockRegistryService)

--- a/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/provider/TestStandardProviderFactory.java
+++ b/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/provider/TestStandardProviderFactory.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.registry.provider;
 
 import org.apache.nifi.registry.extension.BundlePersistenceProvider;
+import org.apache.nifi.registry.extension.ExtensionClassLoader;
 import org.apache.nifi.registry.extension.ExtensionManager;
 import org.apache.nifi.registry.flow.FlowPersistenceProvider;
 import org.apache.nifi.registry.properties.NiFiRegistryProperties;
@@ -24,6 +25,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import javax.sql.DataSource;
+import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -38,7 +40,8 @@ public class TestStandardProviderFactory {
         props.setProperty(NiFiRegistryProperties.PROVIDERS_CONFIGURATION_FILE, "src/test/resources/provider/providers-good.xml");
 
         final ExtensionManager extensionManager = Mockito.mock(ExtensionManager.class);
-        when(extensionManager.getExtensionClassLoader(any(String.class))).thenReturn(this.getClass().getClassLoader());
+        when(extensionManager.getExtensionClassLoader(any(String.class)))
+                .thenReturn(new ExtensionClassLoader("/tmp", new URL[0],this.getClass().getClassLoader()));
 
         final DataSource dataSource = Mockito.mock(DataSource.class);
 
@@ -68,7 +71,8 @@ public class TestStandardProviderFactory {
         props.setProperty(NiFiRegistryProperties.PROVIDERS_CONFIGURATION_FILE, "src/test/resources/provider/providers-good.xml");
 
         final ExtensionManager extensionManager = Mockito.mock(ExtensionManager.class);
-        when(extensionManager.getExtensionClassLoader(any(String.class))).thenReturn(this.getClass().getClassLoader());
+        when(extensionManager.getExtensionClassLoader(any(String.class)))
+                .thenReturn(new ExtensionClassLoader("/tmp", new URL[0],this.getClass().getClassLoader()));
 
         final DataSource dataSource = Mockito.mock(DataSource.class);
 
@@ -82,7 +86,8 @@ public class TestStandardProviderFactory {
         props.setProperty(NiFiRegistryProperties.PROVIDERS_CONFIGURATION_FILE, "src/test/resources/provider/providers-does-not-exist.xml");
 
         final ExtensionManager extensionManager = Mockito.mock(ExtensionManager.class);
-        when(extensionManager.getExtensionClassLoader(any(String.class))).thenReturn(this.getClass().getClassLoader());
+        when(extensionManager.getExtensionClassLoader(any(String.class)))
+                .thenReturn(new ExtensionClassLoader("/tmp", new URL[0],this.getClass().getClassLoader()));
 
         final DataSource dataSource = Mockito.mock(DataSource.class);
 
@@ -96,7 +101,8 @@ public class TestStandardProviderFactory {
         props.setProperty(NiFiRegistryProperties.PROVIDERS_CONFIGURATION_FILE, "src/test/resources/provider/providers-class-not-found.xml");
 
         final ExtensionManager extensionManager = Mockito.mock(ExtensionManager.class);
-        when(extensionManager.getExtensionClassLoader(any(String.class))).thenReturn(this.getClass().getClassLoader());
+        when(extensionManager.getExtensionClassLoader(any(String.class)))
+                .thenReturn(new ExtensionClassLoader("/tmp", new URL[0],this.getClass().getClassLoader()));
 
         final DataSource dataSource = Mockito.mock(DataSource.class);
 

--- a/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/provider/hook/TestScriptEventHookProvider.java
+++ b/nifi-registry-core/nifi-registry-framework/src/test/java/org/apache/nifi/registry/provider/hook/TestScriptEventHookProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.registry.provider.hook;
 
+import org.apache.nifi.registry.extension.ExtensionClassLoader;
 import org.apache.nifi.registry.extension.ExtensionManager;
 import org.apache.nifi.registry.properties.NiFiRegistryProperties;
 import org.apache.nifi.registry.provider.ProviderCreationException;
@@ -25,6 +26,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import javax.sql.DataSource;
+
+import java.net.URL;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -37,7 +40,8 @@ public class TestScriptEventHookProvider {
         props.setProperty(NiFiRegistryProperties.PROVIDERS_CONFIGURATION_FILE, "src/test/resources/provider/hook/bad-script-provider.xml");
 
         final ExtensionManager extensionManager = Mockito.mock(ExtensionManager.class);
-        when(extensionManager.getExtensionClassLoader(any(String.class))).thenReturn(this.getClass().getClassLoader());
+        when(extensionManager.getExtensionClassLoader(any(String.class)))
+                .thenReturn(new ExtensionClassLoader("/tmp", new URL[0],this.getClass().getClassLoader()));
 
         final DataSource dataSource = Mockito.mock(DataSource.class);
 


### PR DESCRIPTION
… ensuring proper context ClassLoader is set

The original problem I was setting out to solve is what was described in the JIRA where didn't do anything with the classpathResources here:

https://github.com/apache/nifi-registry/blob/master/nifi-registry-core/nifi-registry-framework/src/main/java/org/apache/nifi/registry/security/authorization/AuthorizerFactory.java#L340

It turned out there were a few other issues too...

- The introduction of the "FrameworkAuthorizer" broke some of the logic in the AuthorizerFactory that was trying to wrap the onConfigured call with the appropriate context ClassLoader

- The creation of the UGP, AP, and Authorizer should also set the context ClassLoader so it is set during the call to initialize, this is consistent with these methods on NiFi side

- The integrity checks and framework authorizer shouldn't be installed inside createAuthorizer, there could be multiple authorizers and it should only be done around the selected one