### PR TITLE
NIFIREG-363 Adds support for Github Actions CI build on Java 8 and Ja…

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: ci-workflow
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu-build:
+
+    timeout-minutes: 90
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '1.8', '11' ]
+    name: Ubuntu Build NiFi Registry - JDK${{ matrix.java }}
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+    - name: Check NPM Cache
+      uses: actions/cache@v1.1.2
+      with:
+        path: ~/.npm
+        key: linux-${{ matrix.java }}-npm-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          linux-${{ matrix.java }}-npm-
+    - name: Check Maven Com Cache
+      uses: actions/cache@v1.1.2
+      with:
+        path: ~/.m2/repository/com
+        key: linux-${{ matrix.java }}-maven-com-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          linux-${{ matrix.java }}-maven-com-
+    - name: Check Maven Org Cache
+      uses: actions/cache@v1.1.2
+      with:
+        path: ~/.m2/repository/org
+        key: linux-${{ matrix.java }}-maven-org-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          linux-${{ matrix.java }}-maven-org-
+    - name: Check Maven Net Cache
+      uses: actions/cache@v1.1.2
+      with:
+        path: ~/.m2/repository/net
+        key: linux-${{ matrix.java }}-maven-net-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          linux-${{ matrix.java }}-maven-net-
+    - name: Check Maven IO Cache
+      uses: actions/cache@v1.1.2
+      with:
+        path: ~/.m2/repository/io
+        key: linux-${{ matrix.java }}-maven-io-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          linux-${{ matrix.java }}-maven-io-
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1.3.0
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Build with Maven
+      env:
+        MAVEN_OPTS: -Xmx2g -XX:ReservedCodeCacheSize=1g -XX:+UseG1GC -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
+      run: |
+        mvn -version
+        mvn -T 1C install -B -Pcontrib-check -ntp -ff
+        rm -rf ~/.m2/repository/org/apache/nifi


### PR DESCRIPTION
…va 11. Does not yet remove travis. And does not yet support the xvfb/chrome portion for jsUnitTests.