### PR TITLE
NIFIREG-366: updating pom parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>17</version>
+        <version>23</version>
         <relativePath />
     </parent>
     <groupId>org.apache.nifi.registry</groupId>


### PR DESCRIPTION
updating parent pom version to same as NiFi uses. 


associated ticket:
https://issues.apache.org/jira/browse/NIFIREG-366

