### PR TITLE
NIFIREG-364 - Upgrade maven checkstyle version

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -9,6 +9,12 @@
     <module name="FileTabCharacter">
         <property name="eachLine" value="true" />
     </module>
+    <module name="LineLength">
+       <!-- needs extra, because Eclipse formatter ignores the ending left
+            brace -->
+       <property name="max" value="200" />
+       <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
+    </module>
     <module name="TreeWalker">
         <module name="RegexpSinglelineJava">
             <property name="format" value="\s+$" />
@@ -19,12 +25,6 @@
             <property name="message" value="Javadoc @see does not need @link: pick one or the other." />
         </module>
         <module name="OuterTypeFilename" />
-        <module name="LineLength">
-            <!-- needs extra, because Eclipse formatter ignores the ending left
-            brace -->
-            <property name="max" value="200" />
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
-        </module>
         <module name="AvoidStarImport" />
         <module name="UnusedImports">
             <property name="processJavadoc" value="true" />
@@ -64,13 +64,9 @@
         </module>
         <module name="NonEmptyAtclauseDescription" />
         <module name="JavadocMethod">
-            <property name="allowUndeclaredRTE" value="true" />
-            <property name="allowMissingJavadoc" value="true" />
             <property name="allowMissingParamTags" value="true" />
-            <property name="allowMissingThrowsTags" value="true" />
             <property name="allowMissingReturnTag" value="true" />
             <property name="allowedAnnotations" value="Override,Test,BeforeClass,AfterClass,Before,After" />
-            <property name="allowThrowsTagsForSubclasses" value="true" />
         </module>
         <module name="SingleLineJavadoc" />
     </module>

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.29</version>
+                            <version>8.31</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -478,12 +478,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.21</version>
+                            <version>8.29</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -716,5 +716,4 @@
             </properties>
         </profile>
     </profiles>
-
 </project>


### PR DESCRIPTION
Upgraded maven com.puppycrawl.tools:checkstyle version to v8.31. Some rules have been fully deprecated since v8.21, so these were removed from our rules. LineLength had to be moved outside of the TreeWalker module to its own module.