### PR TITLE
NIFIREG-427 Updated references to root key instead of master key in A…

### DIFF
--- a/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -746,21 +746,21 @@ The `encrypt-config` command line tool can be used to encrypt NiFi Registry conf
 
 You can use the following command line options with the `encrypt-config` tool:
 
- * `-h`,`--help`                                  Show usage information (this message)
- * `-v`,`--verbose`                               Enables verbose mode (off by default)
- * `-p`,`--password <password>`                   Protect the files using a password-derived key. If an argument is not provided to this flag, interactive mode will be triggered to prompt the user to enter the password.
- * `-k`,`--key <keyhex>`                          Protect the files using a raw hexadecimal key. If an argument is not provided to this flag, interactive mode will be triggered to prompt the user to enter the key.
- * `--oldPassword <password>`                     If the input files are already protected using a password-derived key, this specifies the old password so that the files can be unprotected before re-protecting.
- * `--oldKey <keyhex>`                            If the input files are already protected using a key, this specifies the raw hexadecimal key so that the files can be unprotected before re-protecting.
- * `-b`,`--bootstrapConf <file>`                  The _bootstrap.conf_ file containing no master key or an existing master key. If a new password/key is specified and no output bootstrap.conf file is specified, then this file will be overwritten to persist the new master key.
- * `-B`,`--outputBootstrapConf <file>`            The destination _bootstrap.conf_ file to persist master key. If specified, the input _bootstrap.conf_ will not be modified.
- * `-r`,`--nifiRegistryProperties <file>`         The _nifi-registry.properties_ file containing unprotected config values, overwritten if no output file specified.
- * `-R`,`--outputNifiRegistryProperties <file>`   The destination _nifi-registry.properties_ file containing protected config values.
- * `-a`,`--authorizersXml <file>`                 The _authorizers.xml_ file containing unprotected config values, overwritten if no output file specified.
- * `-A`,`--outputAuthorizersXml <file>`           The destination _authorizers.xml_ file containing protected config values.
- * `-i`,`--identityProvidersXml <file>`           The _identity-providers.xml_ file containing unprotected config values, overwritten if no output file specified.
- * `-I`,`--outputIdentityProvidersXml <file>`     The destination _identity-providers.xml_ file containing protected config values.
-
+* `-h`,`--help`                                 Show usage information (this message)
+* `-v`,`--verbose`                              Sets verbose mode (default false)
+* `-p`,`--password <password>`                  Protect the files using a password-derived key. If an argument is not provided to this flag, interactive mode will be triggered to prompt the user to enter the password.
+* `-k`,`--key <keyhex>`                         Protect the files using a raw hexadecimal key. If an argument is not provided to this flag, interactive mode will be triggered to prompt the user to enter the key.
+* `--oldPassword <password>`                    If the input files are already protected using a password-derived key, this specifies the old password so that the files can be unprotected before re-protecting.
+* `--oldKey <keyhex>`                           If the input files are already protected using a key, this specifies the raw hexadecimal key so that the files can be unprotected before re-protecting.
+* `-b`,`--bootstrapConf <file>`                 The _bootstrap.conf_ file containing no root key or an existing root key. If a new password or key is specified (using `-p` or `-k`) and no output _bootstrap.conf_ file is specified, then this file will be overwritten to persist the new root key.
+* `-B`,`--outputBootstrapConf <file>`           The destination _bootstrap.conf_ file to persist root key. If specified, the input _bootstrap.conf_ will not be modified.
+* `-r`,`--nifiRegistryProperties <file>`        The _nifi-registry.properties_ file containing unprotected config values, overwritten if no output file specified.
+* `-R`,`--outputNifiRegistryProperties <file>`  The destination _nifi-registry.properties_ file containing protected config values.
+* `-a`,`--authorizersXml <file>`                The _authorizers.xml_ file containing unprotected config values, overwritten if no output file specified.
+* `-A`,`--outputAuthorizersXml <file>`          The destination _authorizers.xml_ file containing protected config values.
+* `-i`,`--identityProvidersXml <file>`          The _identity-providers.xml_ file containing unprotected config values, overwritten if no output file specified.
+* `-I`,`--outputIdentityProvidersXml <file>`    The destination _identity-providers.xml_ file containing protected config values.
+* `--decrypt`                                   Can be used with `-r` to decrypt a previously encrypted NiFi Registry Properties file. Decrypted content is printed to STDOUT.
 
 As an example of how the tool works, assume that you have installed the tool on a machine supporting 256-bit encryption and with the following existing values in the _nifi-registry.properties_ file:
 
@@ -778,7 +778,7 @@ nifi.registry.security.truststorePasswd=
 Enter the following arguments when using the tool:
 
 ----
-./bin/encrypt-config.sh nifi-registry \
+./bin/encrypt-config.sh --nifiRegistry \
 -b bootstrap.conf \
 -k 0123456789ABCDEFFEDCBA98765432100123456789ABCDEFFEDCBA9876543210 \
 -r nifi-registry.properties
@@ -819,7 +819,7 @@ When applied to _identity-providers.xml_ or _authorizers.xml_, the property elem
 Additionally, the _bootstrap.conf_ file is updated with the encryption key as follows:
 
 ----
-# Master key in hexadecimal format for encrypted sensitive configuration values
+# Root key in hexadecimal format for encrypted sensitive configuration values
 nifi.registry.bootstrap.sensitive.key=0123456789ABCDEFFEDCBA98765432100123456789ABCDEFFEDCBA9876543210
 ----
 
@@ -828,16 +828,16 @@ To encrypt additional properties, specify them as comma-separated values in the 
 
 
 If the _nifi-registry.properties_ file already has valid protected values and you wish to protect additional values using the
-same master key already present in your _bootstrap.conf_, then run the tool without specifying a new key:
+same root key already present in your _bootstrap.conf_, then run the tool without specifying a new key:
 
 ----
-# bootstrap.conf already contains master key property
+# bootstrap.conf already contains root key property
 # nifi-registy.properties has been updated for nifi.registry.sensitive.props.additional.keys=...
 
 ./bin/encrypt-config.sh --nifiRegistry -b bootstrap.conf -r nifi-registry.properties
 ----
 
-[sensistive_property_key_migration]
+[sensitive_property_key_migration]
 === Sensitive Property Key Migration
 
 In order to change the key used to encrypt the sensitive values, provide the new key or password using the `-k` or `-p` flags as usual,


### PR DESCRIPTION
…dmin Guide

Also corrected a typo with the first example of using Encrypt-Config in NiFi Registry mode and a misspelling for an anchor.