### PR TITLE
NIFIREG-431 Fix the location of the log directory in Windows

### DIFF
--- a/nifi-registry-core/nifi-registry-resources/src/main/resources/bin/status-nifi-registry.bat
+++ b/nifi-registry-core/nifi-registry-resources/src/main/resources/bin/status-nifi-registry.bat
@@ -37,9 +37,10 @@ set LIB_DIR=%NIFI_REGISTRY_ROOT%\lib
 set SHARED_DIR=%NIFI_REGISTRY_ROOT%\lib\shared
 set BOOTSTRAP_DIR=%NIFI_REGISTRY_ROOT%\lib\bootstrap
 set CONF_DIR=conf
+set NIFI_REGISTRY_LOG_DIR=%NIFI_REGISTRY_ROOT%\logs
 
 set BOOTSTRAP_CONF_FILE=%CONF_DIR%\bootstrap.conf
-set JAVA_ARGS=-Dorg.apache.nifi.registry.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
+set JAVA_ARGS=-Dorg.apache.nifi.registry.bootstrap.config.file=%BOOTSTRAP_CONF_FILE% -Dorg.apache.nifi.registry.bootstrap.config.log.dir=%NIFI_REGISTRY_LOG_DIR%
 
 set JAVA_PARAMS=-cp %LIB_DIR%\*;%SHARED_DIR%\*;%BOOTSTRAP_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.registry.NiFiRegistry
 set BOOTSTRAP_ACTION=status


### PR DESCRIPTION
Thank you for submitting a contribution to Apache NiFi Registry.

Please provide a short description of the PR here:

#### Description of PR

In Windows the log directory is at "org.apache.nifi.registry.bootstrap.config.log.dir_IS_UNDEFINED" because logback expects the value of "org.apache.nifi.registry.bootstrap.config.log.dir" to be available. This bug is somehow related to NIFIREG-250

In other operating systems it works just fine.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with **NIFIREG-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [x] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi-registry` folder?
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you verified that the full build is successful on JDK 8?
- [x] Have you verified that the full build is successful on JDK 11?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [x] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-registry-assembly`?
- [x] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-registry-assembly`?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
