### PR TITLE
NIFIREG-434 Added support for BCFKS Keystore Type

### DIFF
--- a/nifi-registry-core/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/NiFiRegistryClientConfig.java
+++ b/nifi-registry-core/nifi-registry-client/src/main/java/org/apache/nifi/registry/client/NiFiRegistryClientConfig.java
@@ -105,7 +105,7 @@ public class NiFiRegistryClientConfig {
         if (truststoreFilename != null && truststorePass != null && truststoreType != null) {
             try {
                 // prepare the truststore
-                final KeyStore trustStore = KeyStoreUtils.getTrustStore(truststoreType.name());
+                final KeyStore trustStore = KeyStoreUtils.getKeyStore(truststoreType.name());
                 try (final InputStream trustStoreStream = new FileInputStream(new File(truststoreFilename))) {
                     trustStore.load(trustStoreStream, truststorePass.toCharArray());
                 }

--- a/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
+++ b/nifi-registry-core/nifi-registry-docs/src/main/asciidoc/administration-guide.adoc
@@ -86,11 +86,11 @@ NiFi Registry provides several different configuration options for security purp
 |==================================================================================================================================================
 | Property Name | Description
 |`nifi.registry.security.keystore` | Filename of the Keystore that contains the server's private key.
-|`nifi.registry.security.keystoreType` | The type of Keystore. Must be either `PKCS12` or `JKS`.  JKS is the preferred type, PKCS12 files will be loaded with BouncyCastle provider.
+|`nifi.registry.security.keystoreType` | The type of Keystore. Must be `PKCS12` or `JKS` or `BCFKS`.  JKS is the preferred type, BCFKS and PKCS12 files will be loaded with BouncyCastle provider.
 |`nifi.registry.security.keystorePasswd` | The password for the Keystore.
 |`nifi.registry.security.keyPasswd` | The password for the certificate in the Keystore. If not set, the value of `nifi.registry.security.keystorePasswd` will be used.
 |`nifi.registry.security.truststore` | Filename of the Truststore that will be used to authorize those connecting to NiFi Registry.  A secured instance with no Truststore will refuse all incoming connections.
-|`nifi.registry.security.truststoreType` | The type of the Truststore. Must be either `PKCS12` or `JKS`.  JKS is the preferred type, PKCS12 files will be loaded with BouncyCastle provider.
+|`nifi.registry.security.truststoreType` | The type of the Truststore. Must be `PKCS12` or `JKS` or `BCFKS`.  JKS is the preferred type, BCFKS and PKCS12 files will be loaded with BouncyCastle provider.
 |`nifi.registry.security.truststorePasswd` | The password for the Truststore.
 |`nifi.registry.security.needClientAuth` | This specifies that connecting clients must authenticate with a client cert. Setting this to `false` will specify that connecting clients may optionally authenticate with a client cert, but may also login with a username and password against a configured identity provider. The default value is `true`.
 |==================================================================================================================================================

--- a/nifi-registry-core/nifi-registry-security-utils/src/main/java/org/apache/nifi/registry/security/util/KeystoreType.java
+++ b/nifi-registry-core/nifi-registry-security-utils/src/main/java/org/apache/nifi/registry/security/util/KeystoreType.java
@@ -20,6 +20,7 @@ package org.apache.nifi.registry.security.util;
  * Keystore types.
  */
 public enum KeystoreType {
+    BCFKS,
     PKCS12,
-    JKS;
+    JKS
 }

--- a/nifi-registry-core/nifi-registry-security-utils/src/main/java/org/apache/nifi/registry/security/util/SslContextFactory.java
+++ b/nifi-registry-core/nifi-registry-security-utils/src/main/java/org/apache/nifi/registry/security/util/SslContextFactory.java
@@ -119,7 +119,7 @@ public final class SslContextFactory {
         }
 
         // prepare the truststore
-        final KeyStore trustStore = KeyStoreUtils.getTrustStore(truststoreType);
+        final KeyStore trustStore = KeyStoreUtils.getKeyStore(truststoreType);
         try (final InputStream trustStoreStream = new FileInputStream(truststore)) {
             trustStore.load(trustStoreStream, truststorePasswd);
         }
@@ -231,7 +231,7 @@ public final class SslContextFactory {
             UnrecoverableKeyException, KeyManagementException {
 
         // prepare the truststore
-        final KeyStore trustStore = KeyStoreUtils.getTrustStore(truststoreType);
+        final KeyStore trustStore = KeyStoreUtils.getKeyStore(truststoreType);
         try (final InputStream trustStoreStream = new FileInputStream(truststore)) {
             trustStore.load(trustStoreStream, truststorePasswd);
         }

--- a/nifi-registry-core/nifi-registry-security-utils/src/test/java/org/apache/nifi/registry/security/util/KeyStoreUtilsTest.java
+++ b/nifi-registry-core/nifi-registry-security-utils/src/test/java/org/apache/nifi/registry/security/util/KeyStoreUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.registry.security.util;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+
+public class KeyStoreUtilsTest {
+
+    @Test
+    public void testGetKeyStore() throws KeyStoreException {
+        for (final KeystoreType keystoreType : KeystoreType.values()) {
+            final KeyStore keyStore = KeyStoreUtils.getKeyStore(keystoreType.toString());
+            Assert.assertNotNull(String.format("KeyStore not found for Keystore Type [%s]", keystoreType), keyStore);
+            Assert.assertEquals(keystoreType.name(), keyStore.getType());
+        }
+    }
+
+    @Test
+    public void testGetKeyStoreProviderNullType() {
+        final String keyStoreProvider = KeyStoreUtils.getKeyStoreProvider(null);
+        Assert.assertNull(keyStoreProvider);
+    }
+
+    @Test
+    public void testGetKeyStoreProviderBouncyCastleProvider() {
+        final String keyStoreProvider = KeyStoreUtils.getKeyStoreProvider(KeystoreType.PKCS12.name());
+        Assert.assertEquals(BouncyCastleProvider.PROVIDER_NAME, keyStoreProvider);
+    }
+}


### PR DESCRIPTION
#### Description of PR

NIFIREG-434 Adds support for Bouncy Castle FIPS Key Store (BCFKS) in NiFi Registry configuration properties. BCFKS provides improved security for storage of certificates and private keys using AES-CCM and PKBDF2 algorithms for encryption of entries. The implementation leverages the existing Bouncy Castle Security Provider library and updates the KeystoreType enumeration along with related unit tests for KeystoreUtils.  Updates include removing the KeyStoreUtils.getTrustStore() method, which logged a deprecation warning for PKCS12.  PKCS12 is the default keystore type starting in Java 9, so the log message should be removed.

The Java Keytool command can be used to convert JKS or PKCS12 keystores to BCFKS by referencing the Bouncy Castle Security Provider library and provider class using the following command:

keytool -importkeystore -srckeystore keystore.jks -destkeystore keystore.bcfks -deststoretype BCFKS -providerpath bcprov-jdk15on-1.66.jar -providerclass org.bouncycastle.jce.provider.BouncyCastleProvider

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with **NIFIREG-XXXX** where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically `main`)?

- [X] Is your initial contribution a single, squashed commit? _Additional commits in response to PR reviewer feedback should be made on this branch and pushed to allow change tracking. Do not `squash` or use `--force` when pushing to allow for clean monitoring of changes._

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via `mvn -Pcontrib-check clean install` at the root `nifi-registry` folder?
- [X] Have you written or updated unit tests to verify your changes?
- [ ] Have you verified that the full build is successful on JDK 8?
- [X] Have you verified that the full build is successful on JDK 11?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the `LICENSE` file, including the main `LICENSE` file under `nifi-registry-assembly`?
- [ ] If applicable, have you updated the `NOTICE` file, including the main `NOTICE` file found under `nifi-registry-assembly`?

### For documentation related changes:
- [X] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions CI for build issues and submit an update to your PR as soon as possible.
